### PR TITLE
Added LocalizedError conformance to PythonError

### DIFF
--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -228,10 +228,10 @@ extension PythonError : Equatable {
 extension PythonError : CustomStringConvertible {
   public var description: String {
     switch self {
-    case .exception(let p): return "Python Exception: \(p)"
-    case .invalidCall(let p): return "Python Invalid Call: \(p)"
-    case .invalidMember(let m): return "Python Invalid Member: \(m)"
-    case .invalidModule(let m): return "Python Invalid Module: \(m)"
+    case .exception(let p): return "Python exception: \(p)"
+    case .invalidCall(let p): return "Python invalid call: \(p)"
+    case .invalidMember(let m): return "Python invalid member: \(m)"
+    case .invalidModule(let m): return "Python invalid module: \(m)"
     }
   }
 }

--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -228,11 +228,17 @@ extension PythonError : Equatable {
 extension PythonError : CustomStringConvertible {
   public var description: String {
     switch self {
-    case .exception(let p): return "exception: \(p)"
-    case .invalidCall(let p): return "invalidCall: \(p)"
-    case .invalidMember(let m): return "invalidMember: \(m)"
-    case .invalidModule(let m): return "invalidModule: \(m)"
+    case .exception(let p): return "Python Exception: \(p)"
+    case .invalidCall(let p): return "Python Invalid Call: \(p)"
+    case .invalidMember(let m): return "Python Invalid Member: \(m)"
+    case .invalidModule(let m): return "Python Invalid Module: \(m)"
     }
+  }
+}
+
+extension PythonError: LocalizedError {
+  public var errorDescription: String? {
+    return self.description
   }
 }
 

--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -236,9 +236,9 @@ extension PythonError : CustomStringConvertible {
   }
 }
 
-extension PythonError: LocalizedError {
+extension PythonError : LocalizedError {
   public var errorDescription: String? {
-    return self.description
+    return description
   }
 }
 


### PR DESCRIPTION
This enables PythonError descriptions to be printed by `print()`