### PR TITLE
Fix Triggering Conditions for NoEmptyTrailingClosureParentheses Rule

### DIFF
--- a/tools/swift-format/Sources/Rules/NoEmptyTrailingClosureParentheses.swift
+++ b/tools/swift-format/Sources/Rules/NoEmptyTrailingClosureParentheses.swift
@@ -15,7 +15,13 @@ public final class NoEmptyTrailingClosureParentheses: SyntaxFormatRule {
   public override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
     guard node.argumentList.count == 0 else { return node }
 
-    guard let name = node.calledExpression.firstToken?.withoutTrivia() else { return node }
+    guard node.trailingClosure != nil && node.argumentList.isEmpty && node.leftParen != nil else {
+        return node
+    }
+    guard let name = node.calledExpression.lastToken?.withoutTrivia() else {
+        return node
+    }
+
     diagnose(.removeEmptyTrailingParentheses(name: "\(name)"), on: node)
 
     let formattedExp = replaceTrivia(on: node.calledExpression,

--- a/tools/swift-format/Tests/SwiftFormatTests/NoEmptyTrailingClosureParenthesesTests.swift
+++ b/tools/swift-format/Tests/SwiftFormatTests/NoEmptyTrailingClosureParenthesesTests.swift
@@ -17,6 +17,12 @@ public class NoEmptyTrailingClosureParenthesesTests: DiagnosingTestCase {
              }
              greetEnthusiastically() { "John" }
              greetApathetically { "not John" }
+             func myfunc(cls: MyClass) {
+               cls.myClosure { $0 }
+             }
+             func myfunc(cls: MyClass) {
+               cls.myBadClosure() { $0 }
+             }
              """,
       expected: """
                 func greetEnthusiastically(_ nameProvider: () -> String) {
@@ -27,8 +33,16 @@ public class NoEmptyTrailingClosureParenthesesTests: DiagnosingTestCase {
                 }
                 greetEnthusiastically { "John" }
                 greetApathetically { "not John" }
+                func myfunc(cls: MyClass) {
+                  cls.myClosure { $0 }
+                }
+                func myfunc(cls: MyClass) {
+                  cls.myBadClosure { $0 }
+                }
                 """)
     XCTAssertDiagnosed(.removeEmptyTrailingParentheses(name: "greetEnthusiastically"))
+    XCTAssertDiagnosed(.removeEmptyTrailingParentheses(name: "myBadClosure"))
+    XCTAssertNotDiagnosed(.removeEmptyTrailingParentheses(name: "myClosure"))
   }
 
   #if !os(macOS)


### PR DESCRIPTION
The existing implementation of the `NoEmptyTrailingClosureParentheses` rule would misidentify the following code as failing the rule:
```
func myfunc(cls: MyClass) {
  cls.myClosure { $0 }
}
```
It should pass, since no parentheses are used before the trailing closure. Additionally, the rule would print `cls` to the user as the location of the error. With these changes, it would now print `myClosure`.