### PR TITLE
Properly handle colons for empty dictionary declarations

### DIFF
--- a/tools/swift-format/Sources/Rules/ColonWhitespace.swift
+++ b/tools/swift-format/Sources/Rules/ColonWhitespace.swift
@@ -17,6 +17,14 @@ public final class ColonWhitespace: SyntaxFormatRule {
   public override func visit(_ token: TokenSyntax) -> Syntax {
     guard let next = token.nextToken else { return token }
 
+    if token.tokenKind == .colon,
+       token.containingExprStmtOrDecl is DictionaryExprSyntax,
+       next.tokenKind == .rightSquareBracket,
+       token.trailingTrivia.numberOfSpaces > 0 {
+      diagnose(.noSpacesAfterColon, on: token)
+      return token.withoutTrailingTrivia()
+    }
+
     /// Colons own their trailing spaces, so ensure it only has 1 if there's
     /// another token on the same line.
     if token.tokenKind == .colon,
@@ -51,4 +59,6 @@ extension Diagnostic.Message {
     Diagnostic.Message(.warning, "add one space after ':'")
   static let noSpacesBeforeColon =
     Diagnostic.Message(.warning, "remove spaces before ':'")
+  static let noSpacesAfterColon =
+    Diagnostic.Message(.warning, "remove spaces after ':'")
 }

--- a/tools/swift-format/Tests/SwiftFormatTests/ColonWhitespaceTests.swift
+++ b/tools/swift-format/Tests/SwiftFormatTests/ColonWhitespaceTests.swift
@@ -12,12 +12,16 @@ public class ColonWhitespaceTests: DiagnosingTestCase {
              let v2 : Int = 1
              let v3 :Int = 1
              let v4    \t: \t     Int = 1
+             let v5: [Int: String] = [: ]
+             let v6: [Int: String] = [23:  "twenty three"]
              """,
       expected: """
                 let v1: Int = 0
                 let v2: Int = 1
                 let v3: Int = 1
                 let v4: Int = 1
+                let v5: [Int: String] = [:]
+                let v6: [Int: String] = [23: "twenty three"]
                 """)
   }
 


### PR DESCRIPTION
The `ColonWhitespace` rule was incorrectly flagging an error for empty dictionary declarations:
```
let a = [:]
```
It was requiring a space after this colon, when none are needed in this situation.