### PR TITLE
Add offsets to breaks, and fix order for "after" tokens.

### DIFF
--- a/Sources/PrettyPrint/PrettyPrint.swift
+++ b/Sources/PrettyPrint/PrettyPrint.swift
@@ -122,7 +122,7 @@ public class PrettyPrinter {
       indentStack.removeLast()
       breakStack.removeLast()
 
-    case .break(let size):
+    case .break(let size, let offset):
       if isDebugMode {
         if let forcebreak = forceBreakStack.last, forcebreak {
           writeBreakDebugMarker(style: .consistent)
@@ -136,9 +136,9 @@ public class PrettyPrinter {
         // Update the top of the breakStack to reflect the indentation level of the current group.
         let indentValue = indentStack.last ?? 0
         breakStack.removeLast()
-        breakStack.append(indentValue)
+        breakStack.append(indentValue + offset)
 
-        spaceRemaining = maxLineLength - indentValue
+        spaceRemaining = maxLineLength - indentValue - offset
         write("\n")
         lastBreak = true
       } else {
@@ -207,7 +207,7 @@ public class PrettyPrinter {
           lengths[index] += total
         }
 
-      case .break(let size):
+      case .break(let size, _):
         if let index = delimIndexStack.last, case .break = tokens[index] {
           lengths[index] += total
           delimIndexStack.removeLast()

--- a/Sources/PrettyPrint/Token.swift
+++ b/Sources/PrettyPrint/Token.swift
@@ -29,29 +29,19 @@ enum BreakStyle {
 enum Token {
   case comment(Comment, hasTrailingSpace: Bool)
   case newlines(Int)
-  case `break`(Int)
+  case `break`(size: Int, offset: Int)
   case open(BreakStyle, Int)
   case close
   case syntax(TokenSyntax)
 
   static let newline = Token.newlines(1)
-  static let `break` = Token.break(1)
+  static let open = Token.open(.inconsistent, 0)
 
-  var isOpen: Bool {
-    if case .open = self { return true }
-    return false
+  static let `break` = Token.break(size: 1, offset: 0)
+  static func `break`(offset: Int) -> Token {
+    return Token.break(size: 1, offset: offset)
   }
-
-  var columns: Int {
-    switch self {
-    case .comment(let comment, let hasTrailingSpace):
-      return (comment.text.split(separator: "\n").first?.count ?? 0) + (hasTrailingSpace ? 1 : 0)
-    case .break(let spaces):
-      return spaces
-    case .newlines: return 0
-    case .open, .close: return 0
-    case .syntax(let token):
-      return token.text.count + (token.trailingTrivia.hasSpaces ? 1 : 0)
-    }
+  static func `break`(size: Int) -> Token {
+    return Token.break(size: size, offset: 0)
   }
 }


### PR DESCRIPTION
The ability to specify an offset on individual breaks will give us greater flexibility, fine-grained control on indents, and the ability to use different indentation within a single group.

Because the `visit` methods visit the parent nodes first, the tokens in the `after` array are added for the parents before the children, which puts them out of order. This ordering is fine for `before` tokens. The `after` tokens are grouped together for each call to a `visit` method, and then the groups are visited in reverse to ensure that the child's tokens are added to the stream before the parent.