### PR TITLE
Add flag to optionally use pretty-printer

### DIFF
--- a/Sources/swiftformat/Run.swift
+++ b/Sources/swiftformat/Run.swift
@@ -55,7 +55,7 @@ public func lintMain(path: String) -> Int {
 ///
 /// - Parameter path: The absolute path to the source file to be linted.
 /// - Returns: Zero if there were no lint errors, otherwise a non-zero number.
-public func formatMain(path: String, isDebugMode: Bool) -> Int {
+public func formatMain(path: String, isDebugMode: Bool, prettyPrint: Bool) -> Int {
   let url = URL(fileURLWithPath: path)
 
   let config = Configuration()
@@ -75,14 +75,17 @@ public func formatMain(path: String, isDebugMode: Bool) -> Int {
     // Important! We need to cast this to Syntax to avoid going directly into the specialized
     // version of visit(_: SourceFileSyntax), which will not run the pipeline properly.
     let formatted = pipeline.visit(file as Syntax)
-    let printer = PrettyPrinter(
-      configuration: context.configuration,
-      node: formatted,
-      isDebugMode: isDebugMode
-    )
-    print(printer.prettyPrint(), terminator: "")
-//    let output = url.deletingPathExtension().appendingPathExtension("formatted.swift")
-//    try formatted.description.write(to: output, atomically: true, encoding: .utf8)
+
+    if prettyPrint {
+      let printer = PrettyPrinter(
+        configuration: context.configuration,
+        node: formatted,
+        isDebugMode: isDebugMode
+      )
+      print(printer.prettyPrint(), terminator: "")
+    } else {
+      print(formatted.description, terminator: "")
+    }
   } catch {
     fatalError("\(error)")
   }

--- a/Sources/swiftformat/main.swift
+++ b/Sources/swiftformat/main.swift
@@ -43,6 +43,7 @@ struct CommandLineOptions: Codable {
   var verboseLevel = 0
   var mode: Mode = .format
   var isDebugMode: Bool = false
+  var prettyPrint: Bool = false
 }
 
 func processArguments(commandName: String, _ arguments: [String]) -> CommandLineOptions {
@@ -87,6 +88,15 @@ func processArguments(commandName: String, _ arguments: [String]) -> CommandLine
   )) {
     $0.isDebugMode = $1
   }
+  binder.bind(
+    option: parser.add(
+      option: "--pretty-print",
+      shortName: "-p",
+      kind: Bool.self,
+      usage: "Pretty-print the output and automatically apply line-wrapping."
+  )) {
+    $0.prettyPrint = $1
+  }
 
   var opts = CommandLineOptions()
   do {
@@ -107,7 +117,11 @@ func main(_ arguments: [String]) -> Int32 {
   case .format:
     var ret = 0
     for path in options.paths {
-      ret |= formatMain(path: path, isDebugMode: options.isDebugMode)
+      ret |= formatMain(
+        path: path,
+        isDebugMode: options.isDebugMode,
+        prettyPrint: options.prettyPrint
+      )
     }
     return Int32(ret)
   case .lint:


### PR DESCRIPTION
Leave the pretty-printer off by default while it is still under development. It can be activated by command line flags `--pretty-print` or `-p`.