### PR TITLE
Fix `newline` token length calculation

### DIFF
--- a/Sources/PrettyPrint/Token.swift
+++ b/Sources/PrettyPrint/Token.swift
@@ -28,13 +28,17 @@ enum BreakStyle {
 
 enum Token {
   case comment(Comment, hasTrailingSpace: Bool)
-  case newlines(Int)
+  case newlines(Int, offset: Int)
   case `break`(size: Int, offset: Int)
   case open(BreakStyle, Int)
   case close
   case syntax(TokenSyntax)
 
-  static let newline = Token.newlines(1)
+  static let newline = Token.newlines(1, offset: 0)
+  static func newline(offset: Int) -> Token {
+    return Token.newlines(1, offset: offset)
+  }
+
   static let open = Token.open(.inconsistent, 0)
 
   static let `break` = Token.break(size: 1, offset: 0)

--- a/Sources/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/PrettyPrint/TokenStreamCreator.swift
@@ -448,16 +448,16 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: FunctionDeclSyntax) {
-    if let token = node.firstToken {
-      before(token, tokens: .open(.inconsistent, 2))
-    }
-    before(node.signature.input.rightParen, tokens: .break(size: 0), .close)
+    //if let token = node.firstToken {
+    //  before(token, tokens: .open(.inconsistent, 2))
+    //}
+    //before(node.signature.input.rightParen, tokens: .break(size: 0), .close)
     after(node.modifiers?.lastToken, tokens: .break)
     after(node.funcKeyword, tokens: .break)
 
     if let body = node.body {
       before(body.leftBrace, tokens: .break)
-      after(body.leftBrace, tokens: .open(.consistent, 2), .newline)
+      after(body.leftBrace, tokens: .newline(offset: 2), .open(.consistent, 0))
       before(body.rightBrace, tokens: .close)
     }
 
@@ -905,7 +905,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
         }
       case .newlines(let n), .carriageReturns(let n), .carriageReturnLineFeeds(let n):
         if n > 1 {
-          appendToken(.newlines(min(n - 1, config.maximumBlankLines)))
+          appendToken(.newlines(min(n - 1, config.maximumBlankLines), offset: 0))
         }
       default:
         break

--- a/Tests/PrettyPrinterTests/IfStmtTests.swift
+++ b/Tests/PrettyPrinterTests/IfStmtTests.swift
@@ -88,8 +88,8 @@ public class IfStmtTests: PrettyPrintTestCase {
 
       if var1 < var2 {
         let a = 23
-      } else if var3 <
-         var4 {
+      } else
+      if var3 < var4 {
         var b = 123
       }
 


### PR DESCRIPTION
This fixes a bug where `newline` tokens were being assigned negative length values. This was throwing off the length calculations of `break` and `open` tokens, and causing line breaks at incorrect locations. The size of `newline` tokens have constant length, and don't require a calculation the way that normal `break` and `open` tokens do.

The stack used to keep track of `break` indent values is removed, and we instead use flags that track the offset and total indent size of the `break`, which is used by subsequent `open` and `syntax` tokens during printing. The intended behavior is that a `break` token's offset should only affect the token or group immediately following it. If a group immediately follows a `break`, the entire group will be indented according to the `break` token's offset.