### PR TITLE
Support class declarations

### DIFF
--- a/Sources/PrettyPrint/PrettyPrint.swift
+++ b/Sources/PrettyPrint/PrettyPrint.swift
@@ -128,7 +128,10 @@ public class PrettyPrinter {
         writeCloseGroupDebugMarker()
       }
       forceBreakStack.removeLast()
-      indentStack.removeLast()
+      let indentValue = indentStack.popLast() ?? 0
+      // The offset of the last break needs to be adjusted according to its parent group. This is so
+      // the next open token's indent is initialized with the correct value.
+      lastBreakOffset += indentValue
 
     // Create a line break if needed. Calculate the indentation required and adjust spaceRemaining
     // accordingly.
@@ -144,7 +147,7 @@ public class PrettyPrinter {
       // Check if we are forcing breaks within our current group.
       let forcebreak = forceBreakStack.last ?? false
 
-      if length > spaceRemaining || forcebreak {
+      if (length > spaceRemaining || forcebreak) && !lastBreak {
         // Check the indentation of the enclosing group.
         let indentValue = indentStack.last ?? 0
 
@@ -155,8 +158,10 @@ public class PrettyPrinter {
         lastBreakOffset = offset
         lastBreakValue = indentValue + offset
       } else {
-        writeSpaces(size)
-        spaceRemaining -= size
+        if !lastBreak {
+          writeSpaces(size)
+          spaceRemaining -= size
+        }
 
         lastBreak = false
         lastBreakOffset = 0

--- a/Sources/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/PrettyPrint/TokenStreamCreator.swift
@@ -187,6 +187,9 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: MemberDeclBlockSyntax) {
+    for i in 0..<(node.members.count - 1) {
+      after(node.members[i].lastToken, tokens: .newline)
+    }
     super.visit(node)
   }
 
@@ -373,6 +376,18 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: ClassDeclSyntax) {
+    after(node.modifiers?.lastToken, tokens: .break)
+    after(node.classKeyword, tokens: .break)
+
+    before(node.genericWhereClause?.firstToken, tokens: .break, .open(.consistent, 0))
+    after(node.genericWhereClause?.lastToken, tokens: .break, .close)
+
+    if node.genericWhereClause == nil {
+      before(node.members.leftBrace, tokens: .break)
+    }
+    after(node.members.leftBrace, tokens: .break(size: 0, offset: 2), .open(.consistent, 0))
+    before(node.members.rightBrace, tokens: .break(size: 0, offset: -2), .close)
+
     super.visit(node)
   }
 
@@ -529,6 +544,8 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: InheritedTypeSyntax) {
+    before(node.firstToken, tokens: .open(.inconsistent, 0))
+    after(node.lastToken, tokens: .close)
     super.visit(node)
   }
 
@@ -577,11 +594,6 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: PatternBindingSyntax) {
-    if let typeToken = node.typeAnnotation {
-      after(typeToken.lastToken, tokens: .break)
-    } else {
-      after(node.pattern.lastToken, tokens: .break)
-    }
     super.visit(node)
   }
 
@@ -702,6 +714,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: InitializerClauseSyntax) {
+    before(node.equal, tokens: .break)
     after(node.equal, tokens: .break)
     super.visit(node)
   }
@@ -798,6 +811,9 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: TypeInheritanceClauseSyntax) {
+    after(node.colon, tokens: .break(offset: 2))
+    before(node.inheritedTypeCollection.firstToken, tokens: .open(.consistent, 0))
+    after(node.inheritedTypeCollection.lastToken, tokens: .break(size: 0, offset: -2), .close)
     super.visit(node)
   }
 

--- a/Tests/PrettyPrinterTests/ClassDeclTests.swift
+++ b/Tests/PrettyPrinterTests/ClassDeclTests.swift
@@ -1,0 +1,222 @@
+public class ClassDeclTests: PrettyPrintTestCase {
+  public func testBasicClassDeclarations() {
+    let input =
+      """
+      class MyClass {
+        let A: Int
+        let B: Bool
+      }
+      public class MyClass {
+        let A: Int
+        let B: Bool
+      }
+      public class MyLongerClass {
+        let A: Int
+        let B: Bool
+      }
+      """
+
+    let expected =
+      """
+      class MyClass {
+        let A: Int
+        let B: Bool
+      }
+      public class MyClass {
+        let A: Int
+        let B: Bool
+      }
+      public class
+      MyLongerClass {
+        let A: Int
+        let B: Bool
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
+  }
+
+  public func testGenericClassDeclarations() {
+    let input =
+      """
+      class MyClass<T> {
+        let A: Int
+        let B: Bool
+      }
+      class MyClass<T, S> {
+        let A: Int
+        let B: Bool
+      }
+      class MyClass<One, Two, Three, Four> {
+        let A: Int
+        let B: Bool
+      }
+      """
+
+    let expected =
+      """
+      class MyClass<T> {
+        let A: Int
+        let B: Bool
+      }
+      class MyClass<T, S> {
+        let A: Int
+        let B: Bool
+      }
+      class MyClass<
+        One,
+        Two,
+        Three,
+        Four
+      > {
+        let A: Int
+        let B: Bool
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+  }
+
+  public func testClassInheritence() {
+    let input =
+      """
+      class MyClass: SuperOne {
+        let A: Int
+        let B: Bool
+      }
+      class MyClass: SuperOne, SuperTwo {
+        let A: Int
+        let B: Bool
+      }
+      class MyClass: SuperOne, SuperTwo, SuperThree {
+        let A: Int
+        let B: Bool
+      }
+      """
+
+    let expected =
+      """
+      class MyClass: SuperOne {
+        let A: Int
+        let B: Bool
+      }
+      class MyClass: SuperOne, SuperTwo {
+        let A: Int
+        let B: Bool
+      }
+      class MyClass:
+        SuperOne,
+        SuperTwo,
+        SuperThree
+      {
+        let A: Int
+        let B: Bool
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+  }
+
+  public func testClassWhereClause() {
+    let input =
+      """
+      class MyClass<S, T> where S: Collection {
+        let A: Int
+        let B: Double
+      }
+      class MyClass<S, T> where S: Collection, T: ReallyLongClassName {
+        let A: Int
+        let B: Double
+      }
+      """
+
+    let expected =
+      """
+      class MyClass<S, T> where S: Collection {
+        let A: Int
+        let B: Double
+      }
+      class MyClass<S, T>
+      where
+        S: Collection,
+        T: ReallyLongClassName
+      {
+        let A: Int
+        let B: Double
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
+  }
+
+  public func testClassWhereClauseWithInheritence() {
+    let input =
+      """
+      class MyClass<S, T>: SuperOne where S: Collection {
+        let A: Int
+        let B: Double
+      }
+      class MyClass<S, T>: SuperOne, SuperTwo where S: Collection, T: Protocol {
+        let A: Int
+        let B: Double
+      }
+      """
+
+    let expected =
+      """
+      class MyClass<S, T>: SuperOne where S: Collection {
+        let A: Int
+        let B: Double
+      }
+      class MyClass<S, T>: SuperOne, SuperTwo
+      where
+        S: Collection,
+        T: Protocol
+      {
+        let A: Int
+        let B: Double
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
+  }
+
+  public func testClassFullWrap() {
+    let input =
+      """
+      public class MyContainer<BaseCollection, SecondCollection>: MyContainerSuperclass, MyContainerProtocol, SomeoneElsesContainerProtocol, SomeFrameworkContainerProtocol where BaseCollection: Collection, BaseCollection.Element: Equatable, BaseCollection.Element: SomeOtherProtocol {
+        let A: Int
+        let B: Double
+      }
+      """
+
+    let expected =
+
+      """
+      public class MyContainer<
+        BaseCollection,
+        SecondCollection
+      >:
+        MyContainerSuperclass,
+        MyContainerProtocol,
+        SomeoneElsesContainerProtocol,
+        SomeFrameworkContainerProtocol
+      where
+        BaseCollection: Collection,
+        BaseCollection.Element: Equatable,
+        BaseCollection.Element: SomeOtherProtocol
+      {
+        let A: Int
+        let B: Double
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
+}


### PR DESCRIPTION
Support for class declarations is added to the pretty printer.

This PR also fixes a minor bug where `lastBreakOffset` needs to be adjusted when it's group closes, since these offsets are relative to the indent of its group. Otherwise you could end up with negative values for the indent after the group closes.

This PR also updates the behavior of break tokens. If a break token creates a line break, and second break token occurs without first encountering a syntax token, the second break does not create a line break or emit whitespace. This is needed because the implementation of class declaration visit methods requires a case where two breaks occur in this fashion (in between the "inheritance clause" and the "where clause", which is needed to ensure the opening brace is forced to a new line appropriately). We end up with extra spaces or an extra newline without this change.