### PR TITLE
Fix issue where multiple nested groups could have runaway indentation

### DIFF
--- a/Sources/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/PrettyPrint/TokenStreamCreator.swift
@@ -463,6 +463,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: BreakStmtSyntax) {
+    before(node.label, tokens: .break(offset: 2))
     super.visit(node)
   }
 

--- a/Tests/PrettyPrinterTests/SwitchStmtTests.swift
+++ b/Tests/PrettyPrinterTests/SwitchStmtTests.swift
@@ -74,4 +74,39 @@ public class SwitchStmtTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 35)
   }
+
+  public func testNestedSwitch() {
+    let input =
+      """
+      myloop: while a != b {
+        switch a + b {
+        case firstValue:
+          break myloop
+        case secondVale:
+          let c = 123
+          var d = 456
+        default:
+          a += b
+        }
+      }
+      """
+
+    let expected =
+      """
+      myloop: while a != b {
+        switch a + b {
+        case firstValue:
+          break myloop
+        case secondVale:
+          let c = 123
+          var d = 456
+        default:
+          a += b
+        }
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 35)
+  }
 }


### PR DESCRIPTION
This fixes a bug where you can have runaway indentation when you have multiple nested groups with non-zero indentation. For example:
```
if a == c {
  switch square + diceRoll {
  case finalSquare:
    let c = 456
  case nextSquare:
        let a = 123
        let b = "abc"
      default:
                square += diceRoll
                square += board[square]
              }
}
```
This is because the offset of the trailing break tokens aren't being adjusted properly when their enclosing group closes. They should be adjusted by the *relative* indentation of its enclosing group, and not the absolute indentation.