### PR TITLE
Add support for #if compiler control statements

### DIFF
--- a/Sources/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/PrettyPrint/TokenStreamCreator.swift
@@ -268,6 +268,12 @@ private final class TokenStreamCreator: SyntaxVisitor {
     super.visit(node)
   }
 
+  override func visit(_ node: IfConfigClauseSyntax) {
+    after(node.poundKeyword, tokens: .break)
+    after(node.condition?.lastToken, tokens: .newline)
+    super.visit(node)
+  }
+
   override func visit(_ node: MemberDeclBlockSyntax) {
     for i in 0..<(node.members.count - 1) {
       after(node.members[i].lastToken, tokens: .newline)
@@ -315,10 +321,6 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: OperatorDeclSyntax) {
-    super.visit(node)
-  }
-
-  override func visit(_ node: IfConfigClauseSyntax) {
     super.visit(node)
   }
 

--- a/Tests/PrettyPrinterTests/CompilerControlTests.swift
+++ b/Tests/PrettyPrinterTests/CompilerControlTests.swift
@@ -1,0 +1,32 @@
+public class CompilerControlTests: PrettyPrintTestCase {
+  public func testConditionalCompilation() {
+    let input =
+      """
+      #if swift(>=4.0)
+      print("Stuff")
+      #endif
+      #if swift(>=4.0)
+      print("Stuff")
+      #elseif compiler(>=3.0)
+      print("More Stuff")
+      print("Another Line")
+      #endif
+      """
+
+    let expected =
+      """
+      #if swift(>=4.0)
+      print("Stuff")
+      #endif
+      #if swift(>=4.0)
+      print("Stuff")
+      #elseif compiler(>=3.0)
+      print("More Stuff")
+      print("Another Line")
+      #endif
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
+}


### PR DESCRIPTION
This PR adds `#if/#elseif/#endif` blocks. `if #available` doesn't appear to be showing up in the correct AST node, and `#error/#warning` cause the formatter to crash, so they will be addressed in later PRs.