### PR TITLE
The line numbers of nodes should be reported ignoring leading trivia

### DIFF
--- a/Sources/SwiftFormatCore/SyntaxLintRule.swift
+++ b/Sources/SwiftFormatCore/SyntaxLintRule.swift
@@ -38,9 +38,17 @@ extension Rule {
     on node: Syntax?,
     actions: ((inout Diagnostic.Builder) -> Void)? = nil
   ) {
+    // TODO: node?.startLocation should be returning the position ignoring leading trivia. It isn't
+    // working properly, so we are using this workaround until it is fixed.
+    let loc = node.map {
+      SourceLocation(
+        file: context.fileURL.path,
+        position: $0.positionAfterSkippingLeadingTrivia
+      )
+    }
     context.diagnosticEngine?.diagnose(
       message.withRule(self),
-      location: node?.startLocation(in: context.fileURL),
+      location: loc,
       actions: actions
     )
   }


### PR DESCRIPTION
The linter was reporting incorrect line numbers for some lint violations. The reason is that the reported location started at an AST node's leading trivia, rather than the node itself. This change reports the line number ignoring the leading trivia.