### PR TITLE
Fixes to comment behavior

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
@@ -92,6 +92,23 @@ public class CommentTests: PrettyPrintTestCase {
 
       let reallyLongVariableName = 123 // This comment should wrap
 
+      func MyFun() {
+        // just a comment
+      }
+
+      func MyFun() {
+        // Comment 1
+        // Comment 2
+        let a = 123
+
+        let b = 456  // Comment 3
+      }
+
+      func MyFun() {
+        let c = 789 // Comment 4
+        // Comment 5
+      }
+
       let d = 123
       // Trailing Comment
       """
@@ -109,6 +126,23 @@ public class CommentTests: PrettyPrintTestCase {
 
       let reallyLongVariableName = 123
         // This comment should wrap
+
+      func MyFun() {
+        // just a comment
+      }
+
+      func MyFun() {
+        // Comment 1
+        // Comment 2
+        let a = 123
+
+        let b = 456  // Comment 3
+      }
+
+      func MyFun() {
+        let c = 789  // Comment 4
+        // Comment 5
+      }
 
       let d = 123
       // Trailing Comment


### PR DESCRIPTION
This fixes the behavior of comments (particularly trailing line comments) in cases where indentation is present, and within function declarations where the function may not contain anything except a comment.

This takes advantage of the fact that if a comment is a trailing line comment, it will appear as the first piece of the leading trivia (any whitespace in front of the comment will be trailing trivia on the preceding token). Otherwise, the first piece will be a newline.

This also handles the case where comments appear inside of container classes (i.e. Arrays, Dictionaries, etc.), where we force a newline after the comment.