### PR TITLE
Fix wrapping for containers with a trailing comma

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -77,6 +77,17 @@ private final class TokenStreamCreator: SyntaxVisitor {
     afterMap[tok, default: []].append(tokens)
   }
 
+  private func insertToken<Node: Collection>(
+    _ token: Token,
+    betweenChildrenOf collectionNode: Node
+  ) where Node.Element: Syntax, Node.Index == Int {
+    if collectionNode.count > 0 {
+      for i in 0..<(collectionNode.count - 1) {
+        after(collectionNode[i].lastToken, tokens: token)
+      }
+    }
+  }
+
   override func visitPre(_ node: Syntax) {}
 
   override func visit(_ node: DeclNameArgumentsSyntax) {
@@ -100,11 +111,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: TupleElementListSyntax) {
-    if node.count > 0 {
-      for i in 0..<(node.count - 1) {
-        after(node[i].lastToken, tokens: .break)
-      }
-    }
+    insertToken(.break, betweenChildrenOf: node)
     super.visit(node)
   }
 
@@ -125,11 +132,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: ArrayElementListSyntax) {
-    if node.count > 0 {
-      for i in 0..<(node.count - 1) {
-        after(node[i].lastToken, tokens: .break)
-      }
-    }
+    insertToken(.break, betweenChildrenOf: node)
     super.visit(node)
   }
 
@@ -150,11 +153,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: DictionaryElementListSyntax) {
-    if node.count > 0 {
-      for i in 0..<(node.count - 1) {
-        after(node[i].lastToken, tokens: .break)
-      }
-    }
+    insertToken(.break, betweenChildrenOf: node)
     super.visit(node)
   }
 
@@ -423,11 +422,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: CodeBlockSyntax) {
-    if node.statements.count > 0 {
-      for i in 0..<(node.statements.count - 1) {
-        after(node.statements[i].lastToken, tokens: .newline)
-      }
-    }
+    insertToken(.newline, betweenChildrenOf: node.statements)
     super.visit(node)
   }
 
@@ -456,9 +451,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
   override func visit(_ node: SwitchCaseSyntax) {
     before(node.firstToken, tokens: .open)
     after(node.label.lastToken, tokens: .newline(offset: 2), .open(.consistent, 0))
-    for i in 0..<(node.statements.count - 1) {
-      after(node.statements[i].lastToken, tokens: .newline)
-    }
+    insertToken(.newline, betweenChildrenOf: node.statements)
     after(node.lastToken, tokens: .break(offset: -2), .close, .close)
     super.visit(node)
   }

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -99,13 +99,18 @@ private final class TokenStreamCreator: SyntaxVisitor {
     super.visit(node)
   }
 
+  override func visit(_ node: TupleElementListSyntax) {
+    if node.count > 0 {
+      for i in 0..<(node.count - 1) {
+        after(node[i].lastToken, tokens: .break)
+      }
+    }
+    super.visit(node)
+  }
+
   override func visit(_ node: TupleElementSyntax) {
     before(node.firstToken, tokens: .open)
-    if let trailingComma = node.trailingComma {
-      after(trailingComma, tokens: .close, .break)
-    } else {
-      after(node.lastToken, tokens: .close)
-    }
+    after(node.lastToken, tokens: .close)
     super.visit(node)
   }
 
@@ -119,6 +124,21 @@ private final class TokenStreamCreator: SyntaxVisitor {
     super.visit(node)
   }
 
+  override func visit(_ node: ArrayElementListSyntax) {
+    if node.count > 0 {
+      for i in 0..<(node.count - 1) {
+        after(node[i].lastToken, tokens: .break)
+      }
+    }
+    super.visit(node)
+  }
+
+  override func visit(_ node: ArrayElementSyntax) {
+    before(node.firstToken, tokens: .open)
+    after(node.lastToken, tokens: .close)
+    super.visit(node)
+  }
+
   override func visit(_ node: DictionaryExprSyntax) {
     after(
       node.leftSquare,
@@ -126,6 +146,15 @@ private final class TokenStreamCreator: SyntaxVisitor {
       .open(.consistent, 0)
     )
     before(node.rightSquare, tokens: .close, .break(size: 0, offset: -2), .close)
+    super.visit(node)
+  }
+
+  override func visit(_ node: DictionaryElementListSyntax) {
+    if node.count > 0 {
+      for i in 0..<(node.count - 1) {
+        after(node[i].lastToken, tokens: .break)
+      }
+    }
     super.visit(node)
   }
 
@@ -137,11 +166,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
   override func visit(_ node: DictionaryElementSyntax) {
     before(node.firstToken, tokens: .open)
     after(node.colon, tokens: .break(offset: 2))
-    if let trailingComma = node.trailingComma {
-      after(trailingComma, tokens: .close, .break)
-    } else {
-      after(node.lastToken, tokens: .close)
-    }
+    after(node.lastToken, tokens: .close)
     super.visit(node)
   }
 
@@ -744,16 +769,6 @@ private final class TokenStreamCreator: SyntaxVisitor {
     before(node.whereKeyword, tokens: .open(.inconsistent, 2))
     after(node.whereKeyword, tokens: .space)
     after(node.lastToken, tokens: .close)
-    super.visit(node)
-  }
-
-  override func visit(_ node: ArrayElementSyntax) {
-    before(node.firstToken, tokens: .open)
-    if let trailingComma = node.trailingComma {
-      after(trailingComma, tokens: .close, .break)
-    } else {
-      after(node.lastToken, tokens: .close)
-    }
     super.visit(node)
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/ArrayDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ArrayDeclTests.swift
@@ -6,6 +6,7 @@ public class ArrayDeclTests: PrettyPrintTestCase {
       let a: [Bool] = [false, true, true, false]
       let a: [String] = ["One", "Two", "Three", "Four"]
       let a: [String] = ["One", "Two", "Three", "Four", "Five", "Six", "Seven"]
+      let a: [String] = ["One", "Two", "Three", "Four", "Five", "Six", "Seven",]
       """
 
     let expected =
@@ -23,6 +24,15 @@ public class ArrayDeclTests: PrettyPrintTestCase {
         "Five",
         "Six",
         "Seven"
+      ]
+      let a: [String] = [
+        "One",
+        "Two",
+        "Three",
+        "Four",
+        "Five",
+        "Six",
+        "Seven",
       ]
 
       """

--- a/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/DictionaryDeclTests.swift
@@ -6,6 +6,7 @@ public class DictionaryDeclTests: PrettyPrintTestCase {
       let a: [Int: String] = [1: "a", 2: "b", 3: "c"]
       let a: [Int: String] = [1: "a", 2: "b", 3: "c", 4: "d"]
       let a: [Int: String] = [1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f", 7: "g"]
+      let a: [Int: String] = [1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f", 7: "g",]
       """
 
     let expected =
@@ -23,6 +24,15 @@ public class DictionaryDeclTests: PrettyPrintTestCase {
         5: "e",
         6: "f",
         7: "g"
+      ]
+      let a: [Int: String] = [
+        1: "a",
+        2: "b",
+        3: "c",
+        4: "d",
+        5: "e",
+        6: "f",
+        7: "g",
       ]
 
       """

--- a/Tests/SwiftFormatPrettyPrintTests/TupleDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/TupleDeclTests.swift
@@ -6,6 +6,7 @@ public class TupleDeclTests: PrettyPrintTestCase {
       let a: (Int, Int, Int) = (1, 2, 3)
       let a = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
       let a = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+      let a = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,)
       """
 
     let expected =
@@ -28,6 +29,20 @@ public class TupleDeclTests: PrettyPrintTestCase {
         10,
         11,
         12
+      )
+      let a = (
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
       )
 
       """


### PR DESCRIPTION
Originally, I was using the delimiting comma in containers (Arrrays, Dictionaries, and Tuples) to insert breaks. This would result in wrong indentation for the closing bracket if a trailing comma was used. 
```
A = [
  1,
  2,
  3,
  ]
```
This PR inserts the breaks between the elements without referencing the comma.