### PR TITLE
Make CommentWhitespace a lint-only rule.

### DIFF
--- a/Sources/SwiftFormatRules/CommentWhitespace.swift
+++ b/Sources/SwiftFormatRules/CommentWhitespace.swift
@@ -10,109 +10,46 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SwiftFormatCore
 import SwiftSyntax
 
-/// At least two spaces before, and exactly one space after the `//` that begins a line comment.
+/// There are at least two spaces before the `//` that begins a line comment.
 ///
-/// Lint: If an invalid number of spaces appear before or after a comment, a lint error is
-///       raised.
-///
-/// Format: All comments will have at least 2 spaces before, and a single space after, the `//`.
+/// Lint: If an invalid number of spaces appear before a comment, a lint error is raised.
 ///
 /// - SeeAlso: https://google.github.io/swift#horizontal-whitespace
-public final class CommentWhitespace: SyntaxFormatRule {
-  public override func visit (_ token: TokenSyntax) -> Syntax {
-    var pieces = [TriviaPiece]()
-    var validToken = token
-    var needsWhitespaceFix = false
+public final class CommentWhitespace: SyntaxLintRule {
 
-    guard let nextToken = token.nextToken else {
-      // In the case there is a line comment at the end of the file, it ensures
-      // that the line comment has a single space after the `//`.
-      pieces = checksSpacesAfterLineComment(isInvalid: &needsWhitespaceFix, token: token)
-      return needsWhitespaceFix ? token.withLeadingTrivia(Trivia.init(pieces: pieces)) : token
-    }
+  public override func visit(_ token: TokenSyntax) {
+    guard let nextToken = token.nextToken else { return }
 
-    // Ensures the line comment has at least 2 spaces before the `//`.
-    if hasInlineLineComment(trivia: nextToken.leadingTrivia) {
-      let numSpaces = token.trailingTrivia.numberOfSpaces
-      if numSpaces < 2 {
-        needsWhitespaceFix = true
-        let addSpaces = 2 - numSpaces
-        diagnose(.addSpacesBeforeLineComment(count: addSpaces), on:token)
-        validToken = token.withTrailingTrivia(token.trailingTrivia.appending(.spaces(addSpaces)))
+    // Ensures the line comment has at least two spaces before the `//`.
+    if triviaIsEndOfLineComment(nextToken.leadingTrivia) {
+      let numberOfSpaces = token.trailingTrivia.numberOfSpaces
+      if numberOfSpaces < 2 {
+        let spacesToAdd = 2 - numberOfSpaces
+        diagnose(.addSpacesBeforeLineComment(count: spacesToAdd), on: token)
       }
     }
-
-    pieces = checksSpacesAfterLineComment(isInvalid: &needsWhitespaceFix, token: token)
-    return needsWhitespaceFix ? validToken.withLeadingTrivia(Trivia.init(pieces: pieces)) : token
   }
 
-  /// Returns a boolean indicating if the given trivia contains
-  /// a line comment inline with code.
-  private func hasInlineLineComment (trivia: Trivia) -> Bool {
-    // Comments are inline unless the trivia begins with a
-    // with a newline.
+  /// Returns a value indicating whether the given trivia represents an end of line comment.
+  private func triviaIsEndOfLineComment(_ trivia: Trivia) -> Bool {
+    // Comments are end-of-line unless the trivia begins with a newline.
     if let firstPiece = trivia.reversed().last {
-      if case .newlines(_) = firstPiece {
-        return false
-      }
+      if case .newlines(_) = firstPiece { return false }
     }
     for piece in trivia {
-      if case .lineComment(_) = piece {
-        return true
-      }
+      if case .lineComment(_) = piece { return true }
     }
     return false
-  }
-
-  /// Ensures the line comment has exactly one space after the `//`.
-  private func checksSpacesAfterLineComment(isInvalid: inout Bool, token: TokenSyntax) -> [TriviaPiece] {
-    var pieces = [TriviaPiece]()
-
-    for piece in token.leadingTrivia {
-      // Checks if the line comment has exactly one space after the `//`,
-      // if it doesn't it removes or add an space, depending on what the
-      // comment needs in order to follow the right format.
-      if case .lineComment(let text) = piece,
-         let formatText = formatLineComment(textLineComment: text, token: token) {
-        isInvalid = true
-        pieces.append(TriviaPiece.lineComment(formatText))
-      }
-      else {
-        pieces.append(piece)
-      }
-    }
-    return pieces
-  }
-
-  /// Given a string with the text of a line comment, it ensures there
-  /// is exactly one space after the `//`. If the string doesn't follow
-  /// this rule a new string is returned with the right format.
-  private func formatLineComment (textLineComment: String, token: TokenSyntax) -> String? {
-    let text = textLineComment.dropFirst(2)
-    if text.first != " " {
-      diagnose(.addSpaceAfterLineComment, on: token)
-      return "// " + text.trimmingCharacters(in: .whitespaces)
-    }
-    else if text.dropFirst(1).first == " " {
-      diagnose(.removeSpacesAfterLineComment, on: token)
-      return "// " + text.trimmingCharacters(in: .whitespaces)
-    }
-    return nil
   }
 }
 
 extension Diagnostic.Message {
+
   static func addSpacesBeforeLineComment(count: Int) -> Diagnostic.Message {
     let ending = count == 1 ? "" : "s"
     return Diagnostic.Message(.warning, "add \(count) space\(ending) before the //")
   }
-
-  static let addSpaceAfterLineComment =
-    Diagnostic.Message(.warning, "add one space after `//`")
-  static let removeSpacesAfterLineComment =
-    Diagnostic.Message(.warning, "remove excess of spaces after the `//`")
 }

--- a/Sources/swift-format/PopulatePipeline.swift
+++ b/Sources/swift-format/PopulatePipeline.swift
@@ -28,9 +28,120 @@ func populate(_ pipeline: Pipeline) {
   /// MARK: Formatting Passes
 
   pipeline.addFormatter(
+    OneSpaceAfterKeywords.self,
+    for:
+      TokenSyntax.self
+  )
+
+  pipeline.addFormatter(
+    NoCasesWithOnlyFallthrough.self,
+    for:
+      SwitchStmtSyntax.self
+  )
+
+  pipeline.addFormatter(
+    OrderedImports.self,
+    for:
+      SourceFileSyntax.self
+  )
+
+  pipeline.addFormatter(
+    OneVariableDeclarationPerLine.self,
+    for:
+      CodeBlockSyntax.self,
+      ClosureExprSyntax.self,
+      AccessorBlockSyntax.self,
+      SourceFileSyntax.self
+  )
+
+  pipeline.addFormatter(
+    CloseBraceWhitespace.self,
+    for:
+      TokenSyntax.self
+  )
+
+  pipeline.addFormatter(
+    CaseIndentLevelEqualsSwitch.self,
+    for:
+      SwitchStmtSyntax.self
+  )
+
+  pipeline.addFormatter(
+    UseWhereClausesInForLoops.self,
+    for:
+      ForInStmtSyntax.self
+  )
+
+  pipeline.addFormatter(
+    NoEmptyAssociatedValues.self,
+    for:
+      EnumCaseDeclSyntax.self
+  )
+
+  pipeline.addFormatter(
+    UseEarlyExits.self,
+    for:
+      CodeBlockSyntax.self
+  )
+
+  pipeline.addFormatter(
+    OneCasePerLine.self,
+    for:
+      EnumDeclSyntax.self
+  )
+
+  pipeline.addFormatter(
+    NoBlockComments.self,
+    for:
+      TokenSyntax.self
+  )
+
+  pipeline.addFormatter(
     FullyIndirectEnum.self,
     for:
       EnumDeclSyntax.self
+  )
+
+  pipeline.addFormatter(
+    OpenBraceWhitespace.self,
+    for:
+      TokenSyntax.self
+  )
+
+  pipeline.addFormatter(
+    NoLabelsInCasePatterns.self,
+    for:
+      SwitchCaseLabelSyntax.self
+  )
+
+  pipeline.addFormatter(
+    CommaWhitespace.self,
+    for:
+      TokenSyntax.self
+  )
+
+  pipeline.addFormatter(
+    OneSpaceInsideBraces.self,
+    for:
+      TokenSyntax.self
+  )
+
+  pipeline.addFormatter(
+    ReturnVoidInsteadOfEmptyTuple.self,
+    for:
+      FunctionTypeSyntax.self
+  )
+
+  pipeline.addFormatter(
+    MaximumBlankLines.self,
+    for:
+      TokenSyntax.self
+  )
+
+  pipeline.addFormatter(
+    BlankLineBetweenMembers.self,
+    for:
+      MemberDeclBlockSyntax.self
   )
 
   pipeline.addFormatter(
@@ -41,6 +152,33 @@ func populate(_ pipeline: Pipeline) {
   )
 
   pipeline.addFormatter(
+    NoEmptyTrailingClosureParentheses.self,
+    for:
+      FunctionCallExprSyntax.self
+  )
+
+  pipeline.addFormatter(
+    NoVoidReturnOnFunctionSignature.self,
+    for:
+      FunctionSignatureSyntax.self
+  )
+
+  pipeline.addFormatter(
+    NoParensAroundConditions.self,
+    for:
+      IfStmtSyntax.self,
+      ConditionElementSyntax.self,
+      SwitchStmtSyntax.self,
+      RepeatWhileStmtSyntax.self
+  )
+
+  pipeline.addFormatter(
+    CollectionLiteralWhitespace.self,
+    for:
+      TokenSyntax.self
+  )
+
+  pipeline.addFormatter(
     UseShorthandTypeNames.self,
     for:
       SimpleTypeIdentifierSyntax.self,
@@ -48,22 +186,15 @@ func populate(_ pipeline: Pipeline) {
   )
 
   pipeline.addFormatter(
+    AvoidInitializersForLiterals.self,
+    for:
+      FunctionCallExprSyntax.self
+  )
+
+  pipeline.addFormatter(
     GroupNumericLiterals.self,
     for:
       IntegerLiteralExprSyntax.self
-  )
-
-  pipeline.addFormatter(
-    DoNotUseSemicolons.self,
-    for:
-      CodeBlockSyntax.self,
-      SourceFileSyntax.self
-  )
-
-  pipeline.addFormatter(
-    MaximumBlankLines.self,
-    for:
-      TokenSyntax.self
   )
 
   pipeline.addFormatter(
@@ -90,18 +221,16 @@ func populate(_ pipeline: Pipeline) {
   )
 
   pipeline.addFormatter(
-    NoParensAroundConditions.self,
+    ColonWhitespace.self,
     for:
-      IfStmtSyntax.self,
-      ConditionElementSyntax.self,
-      SwitchStmtSyntax.self,
-      RepeatWhileStmtSyntax.self
+      TokenSyntax.self
   )
 
   pipeline.addFormatter(
-    AvoidInitializersForLiterals.self,
+    UseEnumForNamespacing.self,
     for:
-      FunctionCallExprSyntax.self
+      StructDeclSyntax.self,
+      ClassDeclSyntax.self
   )
 
   pipeline.addFormatter(
@@ -117,148 +246,20 @@ func populate(_ pipeline: Pipeline) {
   )
 
   pipeline.addFormatter(
-    UseEarlyExits.self,
-    for:
-      CodeBlockSyntax.self
-  )
-
-  pipeline.addFormatter(
-    ColonWhitespace.self,
-    for:
-      TokenSyntax.self
-  )
-
-  pipeline.addFormatter(
-    NoLabelsInCasePatterns.self,
-    for:
-      SwitchCaseLabelSyntax.self
-  )
-
-  pipeline.addFormatter(
-    NoEmptyAssociatedValues.self,
-    for:
-      EnumCaseDeclSyntax.self
-  )
-
-  pipeline.addFormatter(
-    NoVoidReturnOnFunctionSignature.self,
-    for:
-      FunctionSignatureSyntax.self
-  )
-
-  pipeline.addFormatter(
-    CollectionLiteralWhitespace.self,
-    for:
-      TokenSyntax.self
-  )
-
-  pipeline.addFormatter(
-    ReturnVoidInsteadOfEmptyTuple.self,
-    for:
-      FunctionTypeSyntax.self
-  )
-
-  pipeline.addFormatter(
-    OneCasePerLine.self,
-    for:
-      EnumDeclSyntax.self
-  )
-
-  pipeline.addFormatter(
-    OneVariableDeclarationPerLine.self,
+    DoNotUseSemicolons.self,
     for:
       CodeBlockSyntax.self,
-      ClosureExprSyntax.self,
-      AccessorBlockSyntax.self,
       SourceFileSyntax.self
-  )
-
-  pipeline.addFormatter(
-    NoCasesWithOnlyFallthrough.self,
-    for:
-      SwitchStmtSyntax.self
-  )
-
-  pipeline.addFormatter(
-    OneSpaceInsideBraces.self,
-    for:
-      TokenSyntax.self
-  )
-
-  pipeline.addFormatter(
-    UseEnumForNamespacing.self,
-    for:
-      StructDeclSyntax.self,
-      ClassDeclSyntax.self
-  )
-
-  pipeline.addFormatter(
-    OpenBraceWhitespace.self,
-    for:
-      TokenSyntax.self
-  )
-
-  pipeline.addFormatter(
-    CommaWhitespace.self,
-    for:
-      TokenSyntax.self
-  )
-
-  pipeline.addFormatter(
-    CloseBraceWhitespace.self,
-    for:
-      TokenSyntax.self
-  )
-
-  pipeline.addFormatter(
-    NoBlockComments.self,
-    for:
-      TokenSyntax.self
-  )
-
-  pipeline.addFormatter(
-    OneSpaceAfterKeywords.self,
-    for:
-      TokenSyntax.self
-  )
-
-  pipeline.addFormatter(
-    UseWhereClausesInForLoops.self,
-    for:
-      ForInStmtSyntax.self
-  )
-
-  pipeline.addFormatter(
-    CaseIndentLevelEqualsSwitch.self,
-    for:
-      SwitchStmtSyntax.self
-  )
-
-  pipeline.addFormatter(
-    OrderedImports.self,
-    for:
-      SourceFileSyntax.self
-  )
-
-  pipeline.addFormatter(
-    NoEmptyTrailingClosureParentheses.self,
-    for:
-      FunctionCallExprSyntax.self
-  )
-
-  pipeline.addFormatter(
-    BlankLineBetweenMembers.self,
-    for:
-      MemberDeclBlockSyntax.self
-  )
-
-  pipeline.addFormatter(
-    CommentWhitespace.self,
-    for:
-      TokenSyntax.self
   )
 
   /// MARK: Linting Passes
+
+  pipeline.addLinter(
+    NeverUseImplicitlyUnwrappedOptionals.self,
+    for:
+      SourceFileSyntax.self,
+      VariableDeclSyntax.self
+  )
 
   pipeline.addLinter(
     AlwaysUseLowerCamelCase.self,
@@ -269,73 +270,9 @@ func populate(_ pipeline: Pipeline) {
   )
 
   pipeline.addLinter(
-    NeverUseImplicitlyUnwrappedOptionals.self,
+    UseLetInEveryBoundCaseVariable.self,
     for:
-      SourceFileSyntax.self,
-      VariableDeclSyntax.self
-  )
-
-  pipeline.addLinter(
-    NeverForceUnwrap.self,
-    for:
-      SourceFileSyntax.self,
-      ForcedValueExprSyntax.self,
-      AsExprSyntax.self
-  )
-
-  pipeline.addLinter(
-    OnlyOneTrailingClosureArgument.self,
-    for:
-      FunctionCallExprSyntax.self
-  )
-
-  pipeline.addLinter(
-    DontRepeatTypeInStaticProperties.self,
-    for:
-      ClassDeclSyntax.self,
-      EnumDeclSyntax.self,
-      ProtocolDeclSyntax.self,
-      StructDeclSyntax.self,
-      ExtensionDeclSyntax.self
-  )
-
-  pipeline.addLinter(
-    ValidateDocumentationComments.self,
-    for:
-      FunctionDeclSyntax.self
-  )
-
-  pipeline.addLinter(
-    AllPublicDeclarationsHaveDocumentation.self,
-    for:
-      FunctionDeclSyntax.self,
-      InitializerDeclSyntax.self,
-      DeinitializerDeclSyntax.self,
-      SubscriptDeclSyntax.self,
-      ClassDeclSyntax.self,
-      VariableDeclSyntax.self,
-      StructDeclSyntax.self,
-      ProtocolDeclSyntax.self,
-      TypealiasDeclSyntax.self
-  )
-
-  pipeline.addLinter(
-    NeverUseForceTry.self,
-    for:
-      SourceFileSyntax.self,
-      TryExprSyntax.self
-  )
-
-  pipeline.addLinter(
-    IdentifiersMustBeASCII.self,
-    for:
-      IdentifierPatternSyntax.self
-  )
-
-  pipeline.addLinter(
-    UseSynthesizedInitializer.self,
-    for:
-      StructDeclSyntax.self
+      SwitchCaseLabelSyntax.self
   )
 
   pipeline.addLinter(
@@ -356,6 +293,22 @@ func populate(_ pipeline: Pipeline) {
   )
 
   pipeline.addLinter(
+    CommentWhitespace.self,
+    for:
+      TokenSyntax.self
+  )
+
+  pipeline.addLinter(
+    DontRepeatTypeInStaticProperties.self,
+    for:
+      ClassDeclSyntax.self,
+      EnumDeclSyntax.self,
+      ProtocolDeclSyntax.self,
+      StructDeclSyntax.self,
+      ExtensionDeclSyntax.self
+  )
+
+  pipeline.addLinter(
     AmbiguousTrailingClosureOverload.self,
     for:
       SourceFileSyntax.self,
@@ -364,9 +317,43 @@ func populate(_ pipeline: Pipeline) {
   )
 
   pipeline.addLinter(
-    UseLetInEveryBoundCaseVariable.self,
+    ValidateDocumentationComments.self,
     for:
-      SwitchCaseLabelSyntax.self
+      FunctionDeclSyntax.self
+  )
+
+  pipeline.addLinter(
+    OnlyOneTrailingClosureArgument.self,
+    for:
+      FunctionCallExprSyntax.self
+  )
+
+  pipeline.addLinter(
+    AllPublicDeclarationsHaveDocumentation.self,
+    for:
+      FunctionDeclSyntax.self,
+      InitializerDeclSyntax.self,
+      DeinitializerDeclSyntax.self,
+      SubscriptDeclSyntax.self,
+      ClassDeclSyntax.self,
+      VariableDeclSyntax.self,
+      StructDeclSyntax.self,
+      ProtocolDeclSyntax.self,
+      TypealiasDeclSyntax.self
+  )
+
+  pipeline.addLinter(
+    NeverForceUnwrap.self,
+    for:
+      SourceFileSyntax.self,
+      ForcedValueExprSyntax.self,
+      AsExprSyntax.self
+  )
+
+  pipeline.addLinter(
+    IdentifiersMustBeASCII.self,
+    for:
+      IdentifierPatternSyntax.self
   )
 
   pipeline.addLinter(
@@ -382,5 +369,18 @@ func populate(_ pipeline: Pipeline) {
       StructDeclSyntax.self,
       ProtocolDeclSyntax.self,
       TypealiasDeclSyntax.self
+  )
+
+  pipeline.addLinter(
+    UseSynthesizedInitializer.self,
+    for:
+      StructDeclSyntax.self
+  )
+
+  pipeline.addLinter(
+    NeverUseForceTry.self,
+    for:
+      SourceFileSyntax.self,
+      TryExprSyntax.self
   )
 }

--- a/Tests/SwiftFormatRulesTests/CommentWhitespaceTest.swift
+++ b/Tests/SwiftFormatRulesTests/CommentWhitespaceTest.swift
@@ -5,59 +5,25 @@ import XCTest
 
 public class CommentWhitespaceTest: DiagnosingTestCase {
   public func testInvalidCommentWhiteSpace() {
-    XCTAssertFormatting(
-    CommentWhitespace.self,
-    input: """
-           let initialFactor = 2 //        Line comment of initialFactor.
-           let finalFactor = 2//Line comment of finalFactor.
+    let input = """
+      let initialFactor = 2 //        Line comment of initialFactor.
+      let finalFactor = 2//Line comment of finalFactor.
 
-           //Lorem ipsum dolor sit amet, at nonumes adipisci sea, natum
-           //       offendit vis ex. Audiam legendos expetenda ei quo, nonumes
-           // msensibus eloquentiam ex vix.
-           let fin = 3//        End of file.
-           """,
-    expected: """
-              let initialFactor = 2  // Line comment of initialFactor.
-              let finalFactor = 2  // Line comment of finalFactor.
+      //Lorem ipsum dolor sit amet, at nonumes adipisci sea, natum
+      //       offendit vis ex. Audiam legendos expetenda ei quo, nonumes
+      // msensibus eloquentiam ex vix.
+      let fin = 3//        End of file.
+      """
 
-              // Lorem ipsum dolor sit amet, at nonumes adipisci sea, natum
-              // offendit vis ex. Audiam legendos expetenda ei quo, nonumes
-              // msensibus eloquentiam ex vix.
-              let fin = 3  // End of file.
-              """)
-  }
-  
-  public func testInvalidFuncCommentWhiteSpace() {
-    XCTAssertFormatting(
-    CommentWhitespace.self,
-    input: """
-           func testLineComment(paramA: Int) -> Int {
-             //LineComment.
-             if paramA < 50 {
-               //LineComment.
-               return paramA - 100
-             }
-             //LineComment.
-             return paramA + 100
-           }
-           """,
-    expected: """
-              func testLineComment(paramA: Int) -> Int {
-                // LineComment.
-                if paramA < 50 {
-                  // LineComment.
-                  return paramA - 100
-                }
-                // LineComment.
-                return paramA + 100
-              }
-              """)
+    performLint(CommentWhitespace.self, input: input)
+    XCTAssertDiagnosed(.addSpacesBeforeLineComment(count: 1))
+    XCTAssertDiagnosed(.addSpacesBeforeLineComment(count: 2))
+    XCTAssertDiagnosed(.addSpacesBeforeLineComment(count: 2))
   }
   
   #if !os(macOS)
   static let allTests = [
     CommentWhitespaceTest.testInvalidCommentWhiteSpace,
-    CommentWhitespaceTest.testInvalidFuncCommentWhiteSpace,
-    ]
+  ]
   #endif
 }


### PR DESCRIPTION
Since the pretty printer handles the insertion of spaces before an end-of-line comment, this phase-1 rule can be reduced to lint-only.

This change also removes the requirement that a single space follow the `//` sigil, which was well-intentioned but screws up the banner lines on Swift's own file headers. Trying to intelligently determine what's a banner and what's prose doesn't seem worthwhile.