### PR TITLE
Fix breaking around `as` when followed by `?` or `!`.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -526,7 +526,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: AsExprSyntax) {
     before(node.asTok, tokens: .space)
-    after(node.asTok, tokens: .break)
+    before(node.typeName.firstToken, tokens: .break)
     super.visit(node)
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/AsExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/AsExprTests.swift
@@ -1,0 +1,53 @@
+public class AsExprTests: PrettyPrintTestCase {
+  public func testWithoutPunctuation() {
+    let input =
+      """
+      func foo() {
+        let a = b as Int
+        let c = d
+          as
+          Int
+        let reallyLongVariableName = x as ReallyLongTypeName
+      }
+      """
+
+    let expected =
+      """
+      func foo() {
+        let a = b as Int
+        let c = d as Int
+        let reallyLongVariableName =
+          x as ReallyLongTypeName
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+  }
+
+  public func testWithPunctuation() {
+    let input =
+      """
+      func foo() {
+        let a = b as? Int
+        let c = d
+          as!
+          Int
+        let reallyLongVariableName = x as? ReallyLongTypeName
+      }
+      """
+
+    let expected =
+      """
+      func foo() {
+        let a = b as? Int
+        let c = d as! Int
+        let reallyLongVariableName =
+          x as? ReallyLongTypeName
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+  }
+}


### PR DESCRIPTION
Previously, we were unconditionally breaking after the `as` keyword, which would produce code like this if there was a question mark or exclamation point: `if let foo = bar as ?Baz`