### PR TITLE
Make case indentation rule lint-only.

### DIFF
--- a/Sources/swift-format/PopulatePipeline.swift
+++ b/Sources/swift-format/PopulatePipeline.swift
@@ -40,12 +40,6 @@ func populate(_ pipeline: Pipeline) {
   )
 
   pipeline.addFormatter(
-    CaseIndentLevelEqualsSwitch.self,
-    for:
-      SwitchStmtSyntax.self
-  )
-
-  pipeline.addFormatter(
     CloseBraceWhitespace.self,
     for:
       TokenSyntax.self
@@ -297,6 +291,12 @@ func populate(_ pipeline: Pipeline) {
       SubscriptDeclSyntax.self,
       TypealiasDeclSyntax.self,
       VariableDeclSyntax.self
+  )
+
+  pipeline.addLinter(
+    CaseIndentLevelEqualsSwitch.self,
+    for:
+      SwitchStmtSyntax.self
   )
 
   pipeline.addLinter(

--- a/Tests/SwiftFormatRulesTests/CaseIndentLevelEqualsSwitchTests.swift
+++ b/Tests/SwiftFormatRulesTests/CaseIndentLevelEqualsSwitchTests.swift
@@ -1,71 +1,76 @@
-import Foundation
 import XCTest
-import SwiftSyntax
 
 @testable import SwiftFormatRules
 
 public class CaseIndentLevelEqualsSwitchTests: DiagnosingTestCase {
   public func testsInvalidCaseIndent() {
-    XCTAssertFormatting(
-      CaseIndentLevelEqualsSwitch.self,
-      input: """
-             switch order {
-              
-             case .ascending:
-               print("Ascending")
-                          case .descending:
-               print("Descending")
-                case .same:
-               print("Same")
-             }
-             """,
-      expected: """
-                switch order {
-                
-                case .ascending:
-                  print("Ascending")
-                case .descending:
-                  print("Descending")
-                case .same:
-                  print("Same")
-                }
-                """)
+    let input =
+      """
+      switch order {
+
+      case .ascending:
+        print("Ascending")
+                   case .descending:
+        print("Descending")
+         case .same:
+        print("Same")
+      }
+      """
+
+    performLint(CaseIndentLevelEqualsSwitch.self, input: input)
+    XCTAssertDiagnosed(.adjustCaseIndentation(by: -13))
+    XCTAssertDiagnosed(.adjustCaseIndentation(by: -3))
   }
   
-  public func testsInvalidNestedCaseIndent() {
-    XCTAssertFormatting(
-      CaseIndentLevelEqualsSwitch.self,
-      input: """
-             if true {
-               switch order {
-             case .ascending:
-                 print("Ascending")
-                          case .descending:
-                 print("Descending")
-                case .same:
-                 print("Same")
-               }
-             }
-             """,
-      expected: """
-                if true {
-                  switch order {
-                  case .ascending:
-                    print("Ascending")
-                  case .descending:
-                    print("Descending")
-                  case .same:
-                    print("Same")
-                  }
-                }
-                """)
+  public func testInvalidNestedCaseIndent() {
+    let input =
+      """
+      if true {
+        switch order {
+      case .ascending:
+          print("Ascending")
+                   case .descending:
+          print("Descending")
+         case .same:
+          print("Same")
+        }
+      }
+      """
+
+    performLint(CaseIndentLevelEqualsSwitch.self, input: input)
+    XCTAssertDiagnosed(.adjustCaseIndentation(by: 2))
+    XCTAssertDiagnosed(.adjustCaseIndentation(by: -11))
+    XCTAssertDiagnosed(.adjustCaseIndentation(by: -1))
   }
   
+  public func testInvalidNestedSwitchIndent() {
+    let input =
+      """
+      switch foo {
+        case .bar:
+        switch order {
+      case .ascending:
+          print("Ascending")
+                   case .descending:
+          print("Descending")
+         case .same:
+          print("Same")
+        }
+      }
+      """
+
+    performLint(CaseIndentLevelEqualsSwitch.self, input: input)
+    XCTAssertDiagnosed(.adjustCaseIndentation(by: -2))
+    XCTAssertDiagnosed(.adjustCaseIndentation(by: 2))
+    XCTAssertDiagnosed(.adjustCaseIndentation(by: -11))
+    XCTAssertDiagnosed(.adjustCaseIndentation(by: -1))
+  }
+
   #if !os(macOS)
   static let allTests = [
-    CaseIndentLevelEqualsSwitchTests.testsInvalidCaseIndent,
-    CaseIndentLevelEqualsSwitchTests.testsInvalidNestedCaseIndent
-    ]
+    CaseIndentLevelEqualsSwitchTests.testInvalidCaseIndent,
+    CaseIndentLevelEqualsSwitchTests.testInvalidNestedCaseIndent,
+    CaseIndentLevelEqualsSwitchTests.testInvalidNestedSwitchIndent
+  ]
   #endif
-  
 }


### PR DESCRIPTION
The pretty printer will handle reïndenting cases; this also fixes a bug
where comments between cases were being discarded.