### PR TITLE
Wrap `if case .foo = bar` pattern matching expressions.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1250,6 +1250,9 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: MatchingPatternConditionSyntax) {
+    before(node.firstToken, tokens: .open(.inconsistent, 2))
+    after(node.caseKeyword, tokens: .break)
+    after(node.lastToken, tokens: .close)
     super.visit(node)
   }
 

--- a/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
@@ -97,4 +97,34 @@ public class IfStmtTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20)
   }
+
+  public func testMatchingPatternConditions() {
+    let input =
+      """
+      if case .foo = bar {
+        let a = 123
+        var b = "abc"
+      }
+      if case .reallyLongCaseName = reallyLongVariableName {
+        let a = 123
+        var b = "abc"
+      }
+      """
+
+    let expected =
+      """
+      if case .foo = bar {
+        let a = 123
+        var b = "abc"
+      }
+      if case .reallyLongCaseName =
+             reallyLongVariableName {
+        let a = 123
+        var b = "abc"
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+  }
 }


### PR DESCRIPTION
We weren't handling the `case .foo` part of this yet, thus losing the
space and ending up with `if case.foo = ...`.