### PR TITLE
Add support for UnknownStmtSyntax

### DIFF
--- a/Sources/SwiftFormatCore/Workarounds.swift
+++ b/Sources/SwiftFormatCore/Workarounds.swift
@@ -31,3 +31,17 @@ extension FunctionParameterSyntax {
     return nil
   }
 }
+
+extension TupleTypeElementSyntax {
+  public var secondNameWorkaround: TokenSyntax? {
+    if let secondName = secondName { return secondName }
+    if let secondName = name { return secondName }
+    return nil
+  }
+
+  public var trailingCommaWorkaround: TokenSyntax? {
+    if let comma = trailingComma { return comma }
+    if let comma = ellipsis, comma.tokenKind == .comma { return comma }
+    return nil
+  }
+}

--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -239,6 +239,10 @@ public class PrettyPrinter {
       }
       write(comment.print(indent: lastBreakValue))
       spaceRemaining -= comment.length
+
+    case .verbatim(let verbatim):
+      write(verbatim.print(indent: lastBreakValue))
+      spaceRemaining -= length
     }
   }
 
@@ -337,6 +341,10 @@ public class PrettyPrinter {
       case .comment(let comment):
         lengths.append(comment.length)
         total += comment.length
+
+      case .verbatim:
+        lengths.append(maxLineLength)
+        total += maxLineLength
       }
     }
 

--- a/Sources/SwiftFormatPrettyPrint/Token.swift
+++ b/Sources/SwiftFormatPrettyPrint/Token.swift
@@ -33,6 +33,7 @@ enum Token {
   case newlines(Int, offset: Int)
   case comment(Comment)
   case reset
+  case verbatim(Verbatim)
 
   // Convenience overloads for the enum types
   static let open = Token.open(.inconsistent, 0)
@@ -50,5 +51,9 @@ enum Token {
   }
   static func `break`(size: Int) -> Token {
     return Token.break(size: size, offset: 0)
+  }
+
+  static func verbatim(text: String) -> Token {
+    return Token.verbatim(Verbatim(text: text))
   }
 }

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1285,6 +1285,14 @@ private final class TokenStreamCreator: SyntaxVisitor {
     super.visit(node)
   }
 
+  override func visit(_ token: UnknownStmtSyntax) {
+    appendToken(.verbatim(Verbatim(text: token.description)))
+    if let nextToken = token.nextToken, case .eof = nextToken.tokenKind {
+      appendToken(.newline)
+    }
+    // Call to super.visit is not needed here.
+  }
+
   override func visit(_ token: TokenSyntax) {
     extractLeadingTrivia(token)
     if let before = beforeMap[token] {

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -476,13 +476,14 @@ private final class TokenStreamCreator: SyntaxVisitor {
   override func visit(_ node: TupleTypeSyntax) {
     after(node.leftParen, tokens: .open(.consistent, 2), .break(size: 0))
     before(node.rightParen, tokens: .break(size: 0), .close)
-    for index in 0..<(node.elements.count - 1) {
-      after(node.elements[index].lastToken, tokens: .break)
-    }
     super.visit(node)
   }
 
   override func visit(_ node: FunctionTypeSyntax) {
+    after(node.leftParen, tokens: .break(size: 0, offset: 2), .open(.consistent, 0))
+    before(node.rightParen, tokens: .break(size: 0, offset: -2), .close)
+    before(node.arrow, tokens: .break)
+    before(node.returnType.firstToken, tokens: .break)
     super.visit(node)
   }
 
@@ -990,6 +991,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: AttributedTypeSyntax) {
+    after(node.specifier, tokens: .break)
     super.visit(node)
   }
 
@@ -1107,6 +1109,15 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: TupleTypeElementSyntax) {
+    before(node.firstToken, tokens: .open)
+    after(node.colon, tokens: .break)
+    before(node.secondNameWorkaround, tokens: .break)
+
+    if let trailingComma = node.trailingCommaWorkaround {
+      after(trailingComma, tokens: .close, .break)
+    } else {
+      after(node.lastToken, tokens: .close)
+    }
     super.visit(node)
   }
 

--- a/Sources/SwiftFormatPrettyPrint/Verbatim.swift
+++ b/Sources/SwiftFormatPrettyPrint/Verbatim.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+struct Verbatim {
+  var lines: [String] = []
+  var leadingWhitespaceCounts: [Int] = []
+
+  init(text: String) {
+    tokenizeTextAndTrimWhitespace(text: text)
+  }
+
+  mutating func tokenizeTextAndTrimWhitespace(text: String) {
+    lines = text.split(separator: "\n", omittingEmptySubsequences: false).map { String($0) }
+
+    // Prevents an extra leading new line from being created.
+    if lines[0] == "" {
+      lines.remove(at: 0)
+    }
+
+    // Get the number of leading whitespaces of the first line, and subract this from the number of
+    // leading whitespaces for subsequent lines (if possible). Record the new leading whitespaces
+    // counts, and trim off whitespace from the ends of the strings.
+    let count = countLeadingWhitespaces(text: lines[0])
+    leadingWhitespaceCounts = lines.map { max(countLeadingWhitespaces(text: $0) - count, 0) }
+    lines = lines.map { $0.trimmingCharacters(in: CharacterSet(charactersIn: " ")) }
+  }
+
+  func print(indent: Int) -> String {
+    var output = ""
+    for i in 0..<lines.count {
+      output += String(repeating: " ", count: indent + leadingWhitespaceCounts[i])
+      output += lines[i]
+      if i < lines.count - 1 {
+        output += "\n"
+      }
+    }
+    return output
+  }
+
+  func countLeadingWhitespaces(text: String) -> Int {
+    var count = 0
+    for char in text {
+      if char == " " { count += 1 }
+      else { break }
+    }
+    return count
+  }
+}

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionTypeTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionTypeTests.swift
@@ -1,0 +1,64 @@
+public class FunctionTypeTests: PrettyPrintTestCase {
+  public func testFunctionType() {
+    let input =
+      """
+      func f(g: (_ somevalue: Int) -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (currentLevel: Int) -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (currentLevel: inout Int) -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (variable1: Int, variable2: Double, variable3: Bool) -> Double) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (variable1: Int, variable2: Double, variable3: Bool, variable4: String) -> Double) {
+        let a = 123
+        let b = "abc"
+      }
+      """
+
+    let expected =
+      """
+      func f(g: (_ somevalue: Int) -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (currentLevel: Int) -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(g: (currentLevel: inout Int) -> String?) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(
+        g: (variable1: Int, variable2: Double, variable3: Bool) ->
+        Double
+      ) {
+        let a = 123
+        let b = "abc"
+      }
+      func f(
+        g: (
+          variable1: Int,
+          variable2: Double,
+          variable3: Bool,
+          variable4: String
+        ) -> Double
+      ) {
+        let a = 123
+        let b = "abc"
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
+  }
+}

--- a/Tests/SwiftFormatPrettyPrintTests/UnknownStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/UnknownStmtTests.swift
@@ -1,0 +1,76 @@
+public class UnknownStmtTests: PrettyPrintTestCase {
+
+  /// As SwiftSyntax is updated and becomes more complete, these tests could break since the syntax
+  /// components might not be recognized as "unknown".
+  public func testUnknownStmt() {
+    let input =
+      """
+      if someCondition {
+      if something, #available(OSX 10.12, *) {
+      let a = 123
+      let b = "abc"
+      }
+      }
+
+      if someCondition {
+            if something, #available(OSX 10.12, *) {
+         let a = 123
+      let b = "abc"
+            }
+      }
+
+      if someCondition {
+        if anotherCondition {
+      if something, #available(OSX 10.12, *) {
+        let a = 123
+        let b = "abc"
+      }
+        }
+      }
+
+      if #available(OSX 10.12, *) {
+        // Do stuff
+      } else {
+        let a = 123
+        let b = "abc"
+      }
+
+      """
+
+    let expected =
+      """
+      if someCondition {
+        if something, #available(OSX 10.12, *) {
+        let a = 123
+        let b = "abc"
+        }
+      }
+
+      if someCondition {
+        if something, #available(OSX 10.12, *) {
+        let a = 123
+        let b = "abc"
+        }
+      }
+
+      if someCondition {
+        if anotherCondition {
+          if something, #available(OSX 10.12, *) {
+            let a = 123
+            let b = "abc"
+          }
+        }
+      }
+
+      if #available(OSX 10.12, *) {
+        // Do stuff
+      } else {
+        let a = 123
+        let b = "abc"
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
+}


### PR DESCRIPTION
Some pieces of syntax are not yet known to SwiftSyntax, so they get represented as `UnknownStmtSyntax` nodes. We print these verbatim, since we don't have the ability to format them as we would a typical syntax node. To this end, a new `verbatim` token has been created, which has an associated `Verbatim` object.

The purpose of the `Verbatim` class is to handle printing while obeying the current indentation level. It performs the following steps:
- Split the source text into an array of strings by line.
- Find the number of leading whitespaces for the first line.
- Subtract this from the leading whitespace of all lines if possible.
- Print the text line by line, inserting the new amount of leading whitespace plus the given indentation level.