### PR TITLE
Add support for UnknownStmtSyntax

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -239,6 +239,10 @@ public class PrettyPrinter {
       }
       write(comment.print(indent: lastBreakValue))
       spaceRemaining -= comment.length
+
+    case .verbatim(let verbatim):
+      write(verbatim.print(indent: lastBreakValue))
+      spaceRemaining -= length
     }
   }
 
@@ -337,6 +341,10 @@ public class PrettyPrinter {
       case .comment(let comment):
         lengths.append(comment.length)
         total += comment.length
+
+      case .verbatim:
+        lengths.append(maxLineLength)
+        total += maxLineLength
       }
     }
 

--- a/Sources/SwiftFormatPrettyPrint/Token.swift
+++ b/Sources/SwiftFormatPrettyPrint/Token.swift
@@ -33,6 +33,7 @@ enum Token {
   case newlines(Int, offset: Int)
   case comment(Comment)
   case reset
+  case verbatim(Verbatim)
 
   // Convenience overloads for the enum types
   static let open = Token.open(.inconsistent, 0)
@@ -50,5 +51,9 @@ enum Token {
   }
   static func `break`(size: Int) -> Token {
     return Token.break(size: size, offset: 0)
+  }
+
+  static func verbatim(text: String) -> Token {
+    return Token.verbatim(Verbatim(text: text))
   }
 }

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1274,6 +1274,14 @@ private final class TokenStreamCreator: SyntaxVisitor {
     super.visit(node)
   }
 
+  override func visit(_ token: UnknownStmtSyntax) {
+    appendToken(.verbatim(Verbatim(text: token.description)))
+    if let nextToken = token.nextToken, case .eof = nextToken.tokenKind {
+      appendToken(.newline)
+    }
+    // Call to super.visit is not needed here.
+  }
+
   override func visit(_ token: TokenSyntax) {
     extractLeadingTrivia(token)
     if let before = beforeMap[token] {

--- a/Sources/SwiftFormatPrettyPrint/Verbatim.swift
+++ b/Sources/SwiftFormatPrettyPrint/Verbatim.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+struct Verbatim {
+  var lines: [String] = []
+  var leadingWhitespaceCounts: [Int] = []
+
+  init(text: String) {
+    tokenizeTextAndTrimWhitespace(text: text)
+  }
+
+  mutating func tokenizeTextAndTrimWhitespace(text: String) {
+    lines = text.split(separator: "\n", omittingEmptySubsequences: false).map { String($0) }
+
+    // Prevents an extra leading new line from being created.
+    if lines[0] == "" {
+      lines.remove(at: 0)
+    }
+
+    // Get the number of leading whitespaces of the first line, and subract this from the number of
+    // leading whitespaces for subsequent lines (if possible). Record the new leading whitespaces
+    // counts, and trim off whitespace from the ends of the strings.
+    let count = countLeadingWhitespaces(text: lines[0])
+    leadingWhitespaceCounts = lines.map { max(countLeadingWhitespaces(text: $0) - count, 0) }
+    lines = lines.map { $0.trimmingCharacters(in: CharacterSet(charactersIn: " ")) }
+  }
+
+  func print(indent: Int) -> String {
+    var output = ""
+    for i in 0..<lines.count {
+      output += String(repeating: " ", count: indent + leadingWhitespaceCounts[i])
+      output += lines[i]
+      if i < lines.count - 1 {
+        output += "\n"
+      }
+    }
+    return output
+  }
+
+  func countLeadingWhitespaces(text: String) -> Int {
+    var count = 0
+    for char in text {
+      if char == " " { count += 1 }
+      else { break }
+    }
+    return count
+  }
+}

--- a/Sources/SwiftFormatPrettyPrint/Verbatim.swift
+++ b/Sources/SwiftFormatPrettyPrint/Verbatim.swift
@@ -28,6 +28,8 @@ struct Verbatim {
       lines.remove(at: 0)
     }
 
+    guard lines.count > 0 else { return }
+
     // Get the number of leading whitespaces of the first line, and subract this from the number of
     // leading whitespaces for subsequent lines (if possible). Record the new leading whitespaces
     // counts, and trim off whitespace from the ends of the strings.

--- a/Tests/SwiftFormatPrettyPrintTests/AttributeTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/AttributeTests.swift
@@ -16,6 +16,7 @@ public class AttributeTests: PrettyPrintTestCase {
       @available(iOS 10.0, macOS 10.12, *)
 
 
+
       """
 
     // Do not wrap attributes

--- a/Tests/SwiftFormatPrettyPrintTests/UnknownStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/UnknownStmtTests.swift
@@ -1,0 +1,76 @@
+public class UnknownStmtTests: PrettyPrintTestCase {
+
+  /// As SwiftSyntax is updated and becomes more complete, these tests could break since the syntax
+  /// components might not be recognized as "unknown".
+  public func testUnknownStmt() {
+    let input =
+      """
+      if someCondition {
+      if something, #available(OSX 10.12, *) {
+      let a = 123
+      let b = "abc"
+      }
+      }
+
+      if someCondition {
+            if something, #available(OSX 10.12, *) {
+         let a = 123
+      let b = "abc"
+            }
+      }
+
+      if someCondition {
+        if anotherCondition {
+      if something, #available(OSX 10.12, *) {
+        let a = 123
+        let b = "abc"
+      }
+        }
+      }
+
+      if #available(OSX 10.12, *) {
+        // Do stuff
+      } else {
+        let a = 123
+        let b = "abc"
+      }
+
+      """
+
+    let expected =
+      """
+      if someCondition {
+        if something, #available(OSX 10.12, *) {
+        let a = 123
+        let b = "abc"
+        }
+      }
+
+      if someCondition {
+        if something, #available(OSX 10.12, *) {
+        let a = 123
+        let b = "abc"
+        }
+      }
+
+      if someCondition {
+        if anotherCondition {
+          if something, #available(OSX 10.12, *) {
+            let a = 123
+            let b = "abc"
+          }
+        }
+      }
+
+      if #available(OSX 10.12, *) {
+        // Do stuff
+      } else {
+        let a = 123
+        let b = "abc"
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
+}


### PR DESCRIPTION
Some pieces of syntax are not yet known to SwiftSyntax, so they get represented as `UnknownStmtSyntax` nodes. We print these verbatim, since we don't have the ability to format them as we would a typical syntax node. To this end, a new `verbatim` token has been created, which has an associated `Verbatim` object.

The purpose of the `Verbatim` class is to handle printing while obeying the current indentation level. It performs the following steps:
- Split the source text into an array of strings by line.
- Find the number of leading whitespaces for the first line.
- Subtract this from the leading whitespace of all lines if possible.
- Print the text line by line, inserting the new amount of leading whitespace plus the given indentation level.