### PR TITLE
Correct the behavior of AvoidInitializersForLiterals

### DIFF
--- a/Sources/SwiftFormatRules/AvoidInitializersForLiterals.swift
+++ b/Sources/SwiftFormatRules/AvoidInitializersForLiterals.swift
@@ -38,6 +38,16 @@ public final class AvoidInitializersForLiterals: SyntaxFormatRule {
       return super.visit(node)
     }
 
+    guard node.argumentList.count <= 1 else {
+      return super.visit(node)
+    }
+
+    for arg in node.argumentList {
+      if arg.label != nil {
+        return super.visit(node)
+      }
+    }
+
     let typeName = callee.identifier.text
 
     guard let literal = extractLiteral(node, typeName) else {
@@ -61,6 +71,12 @@ public final class AvoidInitializersForLiterals: SyntaxFormatRule {
       )
     }
 
+    let newAs = replaceTrivia(
+      on: asExpr,
+      token: asExpr.lastToken,
+      trailingTrivia: node.trailingTrivia
+    ) as! AsExprSyntax
+
     let newLiteral = replaceTrivia(
       on: literal,
       token: literal.firstToken,
@@ -70,7 +86,7 @@ public final class AvoidInitializersForLiterals: SyntaxFormatRule {
     return SyntaxFactory.makeSequenceExpr(
       elements: SyntaxFactory.makeExprList([
         newLiteral,
-        asExpr,
+        newAs
       ]))
   }
 }

--- a/Sources/swift-format/PopulatePipeline.swift
+++ b/Sources/swift-format/PopulatePipeline.swift
@@ -28,12 +28,6 @@ func populate(_ pipeline: Pipeline) {
   /// MARK: Formatting Passes
 
   pipeline.addFormatter(
-    AvoidInitializersForLiterals.self,
-    for:
-      FunctionCallExprSyntax.self
-  )
-
-  pipeline.addFormatter(
     BlankLineBetweenMembers.self,
     for:
       MemberDeclBlockSyntax.self
@@ -276,6 +270,12 @@ func populate(_ pipeline: Pipeline) {
       CodeBlockSyntax.self,
       MemberDeclBlockSyntax.self,
       SourceFileSyntax.self
+  )
+
+  pipeline.addLinter(
+    AvoidInitializersForLiterals.self,
+    for:
+      FunctionCallExprSyntax.self
   )
 
   pipeline.addLinter(

--- a/Tests/SwiftFormatRulesTests/AvoidInitializersForLiteralsTests.swift
+++ b/Tests/SwiftFormatRulesTests/AvoidInitializersForLiteralsTests.swift
@@ -5,28 +5,27 @@ import XCTest
 
 public class AvoidInitializersForLiteralsTests: DiagnosingTestCase {
   public func testInitializersForLiterals() {
-    XCTAssertFormatting(
-      AvoidInitializersForLiterals.self,
-      input: """
-             let v1 = UInt32(76)
-             let v2 = UInt8(257)
-             performFunction(x: Int16(54))
-             performFunction(x: Int32(54))
-             performFunction(x: Int64(54))
-             let c = Character("s")
-             if 3 > Int(2) || someCondition {}
-             let a = Int(bitPattern: 123456)
-             """,
-      expected: """
-                let v1 = 76 as UInt32
-                let v2 = 257 as UInt8
-                performFunction(x: 54 as Int16)
-                performFunction(x: 54 as Int32)
-                performFunction(x: 54 as Int64)
-                let c = "s" as Character
-                if 3 > 2 as Int || someCondition {}
-                let a = Int(bitPattern: 123456)
-                """)
+    let input =
+      """
+      let v1 = UInt32(76)
+      let v2 = UInt8(257)
+      performFunction(x: Int16(54))
+      performFunction(x: Int32(54))
+      performFunction(x: Int64(54))
+      let c = Character("s")
+      if 3 > Int(2) || someCondition {}
+      let a = Int(bitPattern: 123456)
+      """
+
+    performLint(AvoidInitializersForLiterals.self, input: input)
+    XCTAssertDiagnosed(.avoidInitializerStyleCast("UInt32(76)"))
+    XCTAssertDiagnosed(.avoidInitializerStyleCast("UInt8(257)"))
+    XCTAssertDiagnosed(.avoidInitializerStyleCast("Int16(54)"))
+    XCTAssertDiagnosed(.avoidInitializerStyleCast("Int32(54)"))
+    XCTAssertDiagnosed(.avoidInitializerStyleCast("Int64(54)"))
+    XCTAssertDiagnosed(.avoidInitializerStyleCast("Character(\"s\")"))
+    XCTAssertDiagnosed(.avoidInitializerStyleCast("Int(2) "))
+    XCTAssertNotDiagnosed(.avoidInitializerStyleCast("Int(bitPattern: 123456)"))
   }
 
   #if !os(macOS)

--- a/Tests/SwiftFormatRulesTests/AvoidInitializersForLiteralsTests.swift
+++ b/Tests/SwiftFormatRulesTests/AvoidInitializersForLiteralsTests.swift
@@ -14,6 +14,8 @@ public class AvoidInitializersForLiteralsTests: DiagnosingTestCase {
              performFunction(x: Int32(54))
              performFunction(x: Int64(54))
              let c = Character("s")
+             if 3 > Int(2) || someCondition {}
+             let a = Int(bitPattern: 123456)
              """,
       expected: """
                 let v1 = 76 as UInt32
@@ -22,6 +24,8 @@ public class AvoidInitializersForLiteralsTests: DiagnosingTestCase {
                 performFunction(x: 54 as Int32)
                 performFunction(x: 54 as Int64)
                 let c = "s" as Character
+                if 3 > 2 as Int || someCondition {}
+                let a = Int(bitPattern: 123456)
                 """)
   }
 


### PR DESCRIPTION
This PR addresses two issues with the `AvoidInitializersForLiterals` rule:

1. Trailing whitespace was not preserved. For example:
```swift
if someValue == Int(2) || anotherValue != Int(3) {
```
would transform to
```swift
if someValue == 2 as Int|| anotherValue != 3 as Int{
```
which would result in a build failure.

2. If an initializer used a labeled argument, it would get transformed anyways, possibly resulting in erroneous behavior: `Int(bitPattern: 123456)` transforms to `123456 as Int`.

We now preserve the trailing trivia of the original syntax node after transforming, and we do not transform initializers that use labeled arguments, or have more than one argument.