### PR TITLE
Deactivate UseEarlyExits rule; not safe to use

### DIFF
--- a/Sources/generate-pipeline/main.swift
+++ b/Sources/generate-pipeline/main.swift
@@ -21,6 +21,9 @@ let outputFile =  sourcesDir.appendingPathComponent("swift-format")
                             .appendingPathComponent("PopulatePipeline.swift")
 let fm = FileManager.default
 
+// These rules will not be added to the pipeline
+let suppressRules = ["UseEarlyExits"]
+
 enum PassKind {
   case format, lint, file
 }
@@ -59,6 +62,7 @@ for baseName in rulesEnumerator {
   for stmt in sourceFile.statements {
     guard let classDecl = stmt.item as? ClassDeclSyntax else { continue }
     let className = classDecl.identifier.text
+    if suppressRules.contains(className) { continue }
     guard let inheritanceClause = classDecl.inheritanceClause else { continue }
     var maybeKind: PassKind? = nil
     for item in inheritanceClause.inheritedTypeCollection {

--- a/Sources/swift-format/PopulatePipeline.swift
+++ b/Sources/swift-format/PopulatePipeline.swift
@@ -199,12 +199,6 @@ func populate(_ pipeline: Pipeline) {
   )
 
   pipeline.addFormatter(
-    UseEarlyExits.self,
-    for:
-      CodeBlockItemListSyntax.self
-  )
-
-  pipeline.addFormatter(
     UseEnumForNamespacing.self,
     for:
       ClassDeclSyntax.self,


### PR DESCRIPTION
The `UseEarlyExits` rule might make the following transformation:
```swift
let v = ReturnAnOptional()
if let v = v {
```
to
```swift
let v = ReturnAnOptional()
guard let v = v else {
```
This will cause a build failure since the scoping is different for `if let` and `guard let`.