### PR TITLE
Assorted Fixes

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -117,6 +117,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: TupleElementSyntax) {
     before(node.firstToken, tokens: .open)
+    after(node.colon, tokens: .break)
     after(node.lastToken, tokens: .close)
     super.visit(node)
   }

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -835,7 +835,11 @@ private final class TokenStreamCreator: SyntaxVisitor {
       node.genericWhereClause?.firstToken,
       tokens: .break, .open(.inconsistent, 0), .break(size: 0), .open(.consistent, 0)
     )
-    after(node.genericWhereClause?.lastToken, tokens: .break, .close, .close)
+    if node.body != nil {
+      after(node.genericWhereClause?.lastToken, tokens: .break, .close, .close)
+    } else {
+      after(node.genericWhereClause?.lastToken, tokens: .close, .close)
+    }
 
     if let body = node.body {
       if node.genericWhereClause == nil {

--- a/Sources/generate-pipeline/main.swift
+++ b/Sources/generate-pipeline/main.swift
@@ -22,7 +22,7 @@ let outputFile =  sourcesDir.appendingPathComponent("swift-format")
 let fm = FileManager.default
 
 // These rules will not be added to the pipeline
-let suppressRules = ["UseEarlyExits"]
+let suppressRules = ["UseEarlyExits", "UseWhereClausesInForLoops"]
 
 enum PassKind {
   case format, lint, file

--- a/Sources/swift-format/PopulatePipeline.swift
+++ b/Sources/swift-format/PopulatePipeline.swift
@@ -234,12 +234,6 @@ func populate(_ pipeline: Pipeline) {
       VariableDeclSyntax.self
   )
 
-  pipeline.addFormatter(
-    UseWhereClausesInForLoops.self,
-    for:
-      ForInStmtSyntax.self
-  )
-
   /// MARK: Linting Passes
 
   pipeline.addLinter(

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
@@ -301,6 +301,36 @@ public class FunctionDeclTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
   }
 
+  public func testBodilessFunctionDecl() {
+    let input =
+      """
+      func myFun()
+
+      func myFun(arg1: Int)
+
+      func myFun() -> Int
+
+      func myFun<T>(arg1: Int)
+
+      func myFun<T>(arg1: Int) where T: S
+      """
+
+    let expected =
+      """
+      func myFun()
+
+      func myFun(arg1: Int)
+
+      func myFun() -> Int
+
+      func myFun<T>(arg1: Int)
+
+      func myFun<T>(arg1: Int) where T: S
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+  }
 
   public func testFunctionFullWrap() {
     let input =

--- a/Tests/SwiftFormatPrettyPrintTests/TupleDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/TupleDeclTests.swift
@@ -49,4 +49,21 @@ public class TupleDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 37)
   }
+
+  public func testLabeledTuples() {
+    let input =
+      """
+      let a = (A: var1, B: var2)
+      var b: (A: Int, B: Double)
+      """
+
+    let expected =
+      """
+      let a = (A: var1, B: var2)
+      var b: (A: Int, B: Double)
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+  }
 }


### PR DESCRIPTION
- Fix trailing whitespace that appears when stubbing a function with a where clause: `func myFun<T>(arg: T) where T: S `
- Fix the spacing around colons for labeled tuple arguments
- Deactivate `UseWhereClausesInForLoops` rule, since it can delete code.