### PR TITLE
Fix formatting of empty type declarations.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/ClassDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClassDeclTests.swift
@@ -278,4 +278,16 @@ public class ClassDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
   }
+
+  public func testEmptyClass() {
+    let input = "class Foo {}"
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 50)
+
+    let wrapped = """
+      class Foo {
+      }
+
+      """
+    assertPrettyPrintEqual(input: input, expected: wrapped, linelength: 11)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/EnumDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/EnumDeclTests.swift
@@ -357,4 +357,16 @@ public class EnumDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
   }
+
+  public func testEmptyEnum() {
+    let input = "enum Foo {}"
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 50)
+
+    let wrapped = """
+      enum Foo {
+      }
+
+      """
+    assertPrettyPrintEqual(input: input, expected: wrapped, linelength: 10)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/ExtensionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ExtensionDeclTests.swift
@@ -233,4 +233,16 @@ public class ExtensionDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
   }
+
+  public func testEmptyExtension() {
+    let input = "extension Foo {}"
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 50)
+
+    let wrapped = """
+      extension Foo {
+      }
+
+      """
+    assertPrettyPrintEqual(input: input, expected: wrapped, linelength: 15)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/ProtocolDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ProtocolDeclTests.swift
@@ -226,4 +226,16 @@ public class ProtocolDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 65)
   }
+
+  public func testEmptyProtocol() {
+    let input = "protocol Foo {}"
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 50)
+
+    let wrapped = """
+      protocol Foo {
+      }
+
+      """
+    assertPrettyPrintEqual(input: input, expected: wrapped, linelength: 14)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/StructDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/StructDeclTests.swift
@@ -278,4 +278,16 @@ public class StructDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
   }
+
+  public func testEmptyStruct() {
+    let input = "struct Foo {}"
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 50)
+
+    let wrapped = """
+      struct Foo {
+      }
+
+      """
+    assertPrettyPrintEqual(input: input, expected: wrapped, linelength: 12)
+  }
 }


### PR DESCRIPTION
This change also does a little rearranging of the order of the TokenStreamCreator visit methods to try to keep related things together; I'll be doing more of this in future PRs.