### PR TITLE
Fix an edge case for trailing comments

### DIFF
--- a/Sources/SwiftFormatCore/Trivia+Convenience.swift
+++ b/Sources/SwiftFormatCore/Trivia+Convenience.swift
@@ -35,6 +35,19 @@ extension Trivia {
     return count
   }
 
+  public var numberOfComments: Int {
+    var count = 0
+    for piece in self {
+      switch piece {
+      case .lineComment, .docLineComment, .blockComment, .docBlockComment:
+        count += 1
+      default:
+        continue
+      }
+    }
+    return count
+  }
+
   public var hasSpaces: Bool {
     for piece in self {
       if case .tabs = piece { return true }

--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -21,9 +21,11 @@ private final class TokenStreamCreator: SyntaxVisitor {
   private var beforeMap = [TokenSyntax: [Token]]()
   private var afterMap = [TokenSyntax: [[Token]]]()
   private let config: Configuration
+  private let maxlinelength: Int
 
   init(configuration: Configuration) {
     self.config = configuration
+    self.maxlinelength = config.lineLength
   }
 
   func makeStream(from node: Syntax) -> [Token] {
@@ -516,13 +518,14 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: CodeBlockSyntax) {
-    insertToken(.newline, betweenChildrenOf: node.statements)
+    insertToken(.break(size: maxlinelength), betweenChildrenOf: node.statements)
     super.visit(node)
   }
 
   override func visit(_ node: CodeBlockItemListSyntax) {
-    if node.parent is AccessorBlockSyntax || node.parent is ClosureExprSyntax || node.parent is IfConfigClauseSyntax, node.count > 0 {
-      insertToken(.newline, betweenChildrenOf: node)
+    if node.parent is AccessorBlockSyntax || node.parent is ClosureExprSyntax ||
+       node.parent is IfConfigClauseSyntax, node.count > 0 {
+      insertToken(.break(size: maxlinelength), betweenChildrenOf: node)
     }
     super.visit(node)
   }
@@ -535,7 +538,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
            node.parent?.parent is AccessorBlockSyntax ||
            node.parent?.parent is IfConfigClauseSyntax
          ) {
-      after(node.lastToken, tokens: .close, .newline)
+      after(node.lastToken, tokens: .close, .break(size: maxlinelength))
     } else {
       after(node.lastToken, tokens: .close)
     }
@@ -1385,16 +1388,11 @@ private final class TokenStreamCreator: SyntaxVisitor {
     appendToken(.break(size: 2, offset: 0))
     appendToken(.comment(commentToken, wasEndOfLine: true))
 
-    if isInContainer(token) {
-      appendToken(.newline)
+    if nextToken != nil, ["}", ")"].contains(nextToken?.withoutTrivia().text), trivia.numberOfComments == 1 {
+      appendToken(.break(size: maxlinelength, offset: -2))
+    } else {
+      appendToken(.break(size: maxlinelength))
     }
-  }
-
-  private func isInContainer(_ token: TokenSyntax) -> Bool {
-    if token.parent is ArrayElementSyntax || token.parent is DictionaryElementSyntax || token.parent is TupleElementSyntax {
-      return true
-    }
-    return false
   }
 
   private func extractLeadingTrivia(_ token: TokenSyntax) {
@@ -1410,16 +1408,16 @@ private final class TokenStreamCreator: SyntaxVisitor {
               (["{", "in"].contains { $0 == previousToken.withoutTrivia().text }) {
               // do nothing
             } else {
-              appendToken(.newline)
+              appendToken(.break(size: maxlinelength))
             }
           }
 
           appendToken(.comment(Comment(kind: .line, text: text), wasEndOfLine: false))
 
           if token.withoutTrivia().text == "}" {
-            appendToken(.newline(offset: -2))
+            appendToken(.break(size: maxlinelength, offset: -2))
           } else {
-            appendToken(.newline)
+            appendToken(.break(size: maxlinelength))
           }
         }
 
@@ -1430,16 +1428,16 @@ private final class TokenStreamCreator: SyntaxVisitor {
               previousToken.withoutTrivia().text == "{" {
               // do nothing
             } else {
-              appendToken(.newline)
+              appendToken(.break(size: maxlinelength))
             }
           }
 
           appendToken(.comment(Comment(kind: .block, text: text), wasEndOfLine: false))
 
           if token.withoutTrivia().text == "}" {
-            appendToken(.newline(offset: -2))
+            appendToken(.break(size: maxlinelength, offset: -2))
           } else {
-            appendToken(.newline)
+            appendToken(.break(size: maxlinelength))
           }
         }
 

--- a/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/CommentTests.swift
@@ -109,6 +109,22 @@ public class CommentTests: PrettyPrintTestCase {
         // Comment 5
       }
 
+      let a = myfun(var1: 123 // Cmt 7
+      )
+
+      guard condition else { return // Cmt 6
+      }
+
+      switch myvar {
+      case .one, .two, // three
+           .four:
+        dostuff()
+      default: ()
+      }
+
+      let a = 123 +  // comment
+        b + c
+
       let d = 123
       // Trailing Comment
       """
@@ -142,6 +158,27 @@ public class CommentTests: PrettyPrintTestCase {
         let c = 789  // Comment 4
         // Comment 5
       }
+
+      let a = myfun(
+        var1: 123  // Cmt 7
+      )
+
+      guard condition else {
+        return  // Cmt 6
+      }
+
+      switch myvar {
+      case .one,
+           .two,  // three
+           .four:
+        dostuff()
+      default:
+        ()
+      }
+
+      let a =
+        123 +  // comment
+        b + c
 
       let d = 123
       // Trailing Comment
@@ -299,6 +336,12 @@ public class CommentTests: PrettyPrintTestCase {
 
       let reallyLongVariableName = 123  /* This comment should not wrap */
 
+      let a = myfun(var1: 123 /* Cmt 5 */
+      )
+
+      guard condition else { return /* Cmt 6 */
+      }
+
       let d = 123
       /* Trailing Comment */
       """
@@ -315,6 +358,14 @@ public class CommentTests: PrettyPrintTestCase {
          Comment 4 */
 
       let reallyLongVariableName = 123  /* This comment should not wrap */
+
+      let a = myfun(
+        var1: 123  /* Cmt 5 */
+      )
+
+      guard condition else {
+        return  /* Cmt 6 */
+      }
 
       let d = 123
       /* Trailing Comment */


### PR DESCRIPTION
This PR fixes a situation where code with a trailing line comment might wrap in the following way:
```swift
guard let a = SomeOptional() else { return value  // comment
}
```
wraps to
```swift
guard let a = SomeOptional() else { return value  // comment }
```
which will cause a build failure.