### PR TITLE
Correct the Verbatim Token Length Calculation

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -355,9 +355,17 @@ public class PrettyPrinter {
         lengths.append(comment.length)
         total += comment.length
 
-      case .verbatim:
-        lengths.append(maxLineLength)
-        total += maxLineLength
+      case .verbatim(let verbatim):
+        var length: Int
+        if verbatim.lines.count > 1 {
+          length = maxLineLength
+        } else if verbatim.lines.count == 0 {
+          length = 0
+        } else {
+          length = verbatim.lines[0].count
+        }
+        lengths.append(length)
+        total += length
       }
     }
 

--- a/Tests/SwiftFormatPrettyPrintTests/StringTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/StringTests.swift
@@ -3,6 +3,7 @@ public class StringTests: PrettyPrintTestCase {
     let input =
       """
       let a = "abc"
+      myFun("Some string \\(a + b)")
       let b = "A really long string that should not wrap"
       let c = "A really long string with \\(a + b) some expressions \\(c + d)"
       """
@@ -10,6 +11,7 @@ public class StringTests: PrettyPrintTestCase {
     let expected =
       """
       let a = "abc"
+      myFun("Some string \\(a + b)")
       let b =
         "A really long string that should not wrap"
       let c =
@@ -17,6 +19,6 @@ public class StringTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20)
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 35)
   }
 }


### PR DESCRIPTION
If a Verbatim token have multiple lines, they have a length equal to the maximum line width. If they are single-line, the length is equal to the number of characters.