### PR TITLE
Refactor function-like decls, remove spaces in empty bodies.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/DeinitializerDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/DeinitializerDeclTests.swift
@@ -76,4 +76,25 @@ public class DeinitializerDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
   }
+
+  public func testEmptyDeinitializer() {
+    // The comment inside the class prevents it from *also* being collapsed onto a single line.
+    let input = """
+      class X {
+        //
+        deinit {}
+      }
+      """
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 50)
+    
+    let wrapped = """
+      class X {
+        //
+        deinit {
+        }
+      }
+
+      """
+    assertPrettyPrintEqual(input: input, expected: wrapped, linelength: 10)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
@@ -365,4 +365,16 @@ public class FunctionDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
   }
+
+  public func testEmptyFunction() {
+    let input = "func foo() {}"
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 50)
+    
+    let wrapped = """
+      func foo() {
+      }
+
+      """
+    assertPrettyPrintEqual(input: input, expected: wrapped, linelength: 12)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/InitializerDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/InitializerDeclTests.swift
@@ -295,4 +295,25 @@ public class InitializerDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
   }
+
+  public func testEmptyInitializer() {
+    // The comment inside the struct prevents it from *also* being collapsed onto a single line.
+    let input = """
+      struct X {
+        //
+        init() {}
+      }
+      """
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 50)
+    
+    let wrapped = """
+      struct X {
+        //
+        init() {
+        }
+      }
+
+      """
+    assertPrettyPrintEqual(input: input, expected: wrapped, linelength: 10)
+  }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/SubscriptDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SubscriptDeclTests.swift
@@ -233,4 +233,24 @@ public class SubscriptDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 34)
   }
+
+  public func testEmptySubscript() {
+    // The comment inside the struct prevents it from *also* being collapsed onto a single line.
+    let input = """
+      struct X {
+        //
+        subscript(i: Int) {}
+      }
+      """
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 50)
+    
+    let wrapped = """
+      struct X {
+        //
+        subscript(i: Int) {}
+      }
+
+      """
+    assertPrettyPrintEqual(input: input, expected: wrapped, linelength: 21)
+  }
 }


### PR DESCRIPTION
Getting this working was a slog. Some of the things I did here (like checking whether the body is empty of syntax nodes *OR* comments) need to be ported back to the type decl visitors as well, which I'll do in the next PR.