### PR TITLE
Refactor indentation of control flow statements.

### DIFF
--- a/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
@@ -118,9 +118,7 @@ public class ForInStmtTests: PrettyPrintTestCase {
       loopLabel: for element in container {
         let a = 123
         let b = "abc"
-        if element == "" {
-          continue
-        }
+        if element == "" { continue }
         for c in anotherContainer {
           let d = "456"
           continue elementLoop

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
@@ -144,19 +144,13 @@ public class FunctionCallTests: PrettyPrintTestCase {
     let expected =
     """
       let a = afunc() {
-        if condition1 {
-          return true
-        }
+        if condition1 { return true }
         return false
       }
 
       let a = afunc() {
-        if condition1 {
-          return true
-        }
-        if condition2 {
-          return true
-        }
+        if condition1 { return true }
+        if condition2 { return true }
         return false
       }
 

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
@@ -96,9 +96,7 @@ public class FunctionDeclTests: PrettyPrintTestCase {
       """
       func myFun(var1: Int) throws -> Double {
         print("Hello World")
-        if badCondition {
-          throw Error
-        }
+        if badCondition { throw Error }
         return 1.0
       }
       func reallyLongName(
@@ -107,9 +105,7 @@ public class FunctionDeclTests: PrettyPrintTestCase {
         var3: Bool
       ) throws -> Double {
         print("Hello World")
-        if badCondition {
-          throw Error
-        }
+        if badCondition { throw Error }
         return 1.0
       }
 


### PR DESCRIPTION
I departed from the pattern slightly for `do/catch` blocks and used a `maxlinelength` break there to force the body to wrap even if it fits on a single line, because I didn't like the way this came out:

```swift
do { foo() } catch error as FooError { bar() } catch error as BarError { baz() }
```

Things also got a little weird if a wrap was needed in the middle of that. Since we're likely to force the `catch` lines onto their own line instead of keeping them right after the `}`, I punted on it for now and just preserved existing test behavior.