### PR TITLE
[Tweaks] First cut of discretionary line break handling.

### DIFF
--- a/Sources/SwiftFormatConfiguration/Configuration.swift
+++ b/Sources/SwiftFormatConfiguration/Configuration.swift
@@ -33,6 +33,15 @@ public class Configuration: Codable {
   /// All indentation will be conducted in multiples of this configuration.
   public var indentation: Indent = .spaces(2)
 
+  /// Indicates that the formatter should try to respect users' discretionary line breaks when
+  /// possible.
+  ///
+  /// For example, a short `if` statement and its single-statement body might be able to fit on one
+  /// line, but for readability the user might break it inside the curly braces. If this setting is
+  /// true, those line breaks will be kept. If this setting is false, the formatter will act more
+  /// "opinionated" and collapse the statement onto a single line.
+  public var respectsExistingLineBreaks = true
+
   /// MARK: Rule-specific configuration
 
   /// Rules for limiting blank lines between members.

--- a/Tests/SwiftFormatPrettyPrintTests/AccessorTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/AccessorTests.swift
@@ -75,7 +75,9 @@ public class AccessorTests: PrettyPrintTestCase {
       }
       struct MyStruct {
         var memberValue: Int
-        var SomeValue: Int { return 123 }
+        var SomeValue: Int {
+          return 123
+        }
         var AnotherValue: Double {
           let out = 1.23
           return out

--- a/Tests/SwiftFormatPrettyPrintTests/AsExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/AsExprTests.swift
@@ -5,8 +5,7 @@ public class AsExprTests: PrettyPrintTestCase {
       func foo() {
         let a = b as Int
         let c = d
-          as
-          Int
+          as Int
         let reallyLongVariableName = x as ReallyLongTypeName
       }
       """
@@ -15,7 +14,9 @@ public class AsExprTests: PrettyPrintTestCase {
       """
       func foo() {
         let a = b as Int
-        let c = d as Int
+        let c =
+          d
+          as Int
         let reallyLongVariableName =
           x as ReallyLongTypeName
       }
@@ -31,8 +32,7 @@ public class AsExprTests: PrettyPrintTestCase {
       func foo() {
         let a = b as? Int
         let c = d
-          as!
-          Int
+          as! Int
         let reallyLongVariableName = x as? ReallyLongTypeName
       }
       """
@@ -41,7 +41,9 @@ public class AsExprTests: PrettyPrintTestCase {
       """
       func foo() {
         let a = b as? Int
-        let c = d as! Int
+        let c =
+          d
+          as! Int
         let reallyLongVariableName =
           x as? ReallyLongTypeName
       }

--- a/Tests/SwiftFormatPrettyPrintTests/DeinitializerDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/DeinitializerDeclTests.swift
@@ -21,7 +21,9 @@ public class DeinitializerDeclTests: PrettyPrintTestCase {
           print("Hello World")
           let a = 23
         }
-        deinit { let a = 23 }
+        deinit {
+          let a = 23
+        }
         deinit {
           let a = "AAAA BBBB CCCC DDDD EEEE FFFF"
         }

--- a/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ForInStmtTests.swift
@@ -120,7 +120,9 @@ public class ForInStmtTests: PrettyPrintTestCase {
       loopLabel: for element in container {
         let a = 123
         let b = "abc"
-        if element == "" { continue }
+        if element == "" {
+          continue
+        }
         for c in anotherContainer {
           let d = "456"
           continue elementLoop

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
@@ -144,13 +144,19 @@ public class FunctionCallTests: PrettyPrintTestCase {
     let expected =
     """
       let a = afunc() {
-        if condition1 { return true }
+        if condition1 {
+          return true
+        }
         return false
       }
 
       let a = afunc() {
-        if condition1 { return true }
-        if condition2 { return true }
+        if condition1 {
+          return true
+        }
+        if condition2 {
+          return true
+        }
         return false
       }
 

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
@@ -30,7 +30,9 @@ public class FunctionDeclTests: PrettyPrintTestCase {
         print("Hello World")
         let a = 23
       }
-      func myFun() { let a = 23 }
+      func myFun() {
+        let a = 23
+      }
       func myFun() {
         let a = "AAAA BBBB CCCC DDDD EEEE FFFF"
       }
@@ -96,7 +98,9 @@ public class FunctionDeclTests: PrettyPrintTestCase {
       """
       func myFun(var1: Int) throws -> Double {
         print("Hello World")
-        if badCondition { throw Error }
+        if badCondition {
+          throw Error
+        }
         return 1.0
       }
       func reallyLongName(
@@ -105,7 +109,9 @@ public class FunctionDeclTests: PrettyPrintTestCase {
         var3: Bool
       ) throws -> Double {
         print("Hello World")
-        if badCondition { throw Error }
+        if badCondition {
+          throw Error
+        }
         return 1.0
       }
 

--- a/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
@@ -87,7 +87,9 @@ public class IfStmtTests: PrettyPrintTestCase {
       else if d < e {
         var b = 123
       }
-      else { var c = 456 }
+      else {
+        var c = 456
+      }
 
       if var1 < var2 {
         let a = 23

--- a/Tests/SwiftFormatPrettyPrintTests/InitializerDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/InitializerDeclTests.swift
@@ -33,7 +33,9 @@ public class InitializerDeclTests: PrettyPrintTestCase {
           print("Hello World")
           let a = 23
         }
-        init() { let a = 23 }
+        init() {
+          let a = 23
+        }
         init() {
           let a = "AAAA BBBB CCCC DDDD EEEE FFFF"
         }
@@ -78,7 +80,9 @@ public class InitializerDeclTests: PrettyPrintTestCase {
           print("Hello World")
           let a = 23
         }
-        init?() { let a = 23 }
+        init?() {
+          let a = 23
+        }
         init!() {
           let a = "AAAA BBBB CCCC DDDD EEEE FFFF"
         }
@@ -112,7 +116,9 @@ public class InitializerDeclTests: PrettyPrintTestCase {
           reallyLongLabelVar1: Int,
           var2: Double,
           var3: Bool
-        ) throws { print("Hello World") }
+        ) throws {
+          print("Hello World")
+        }
       }
 
       """

--- a/Tests/SwiftFormatPrettyPrintTests/SubscriptDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SubscriptDeclTests.swift
@@ -59,7 +59,9 @@ public class SubscriptDeclTests: PrettyPrintTestCase {
     let expected =
       """
       struct MyStruct {
-        subscript<T>(index: T) -> Double { return 1.23 }
+        subscript<T>(index: T) -> Double {
+          return 1.23
+        }
         subscript<S, T>(row: S, col: T) -> Double {
           return self.values[row][col]
         }

--- a/Tests/SwiftFormatPrettyPrintTests/TernaryExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/TernaryExprTests.swift
@@ -16,7 +16,10 @@ public class TernaryExprTests: PrettyPrintTestCase {
       """
       let x = a ? b : c
       let y = a ? b : c
-      let z = a ? b : c
+      let z =
+        a
+          ? b
+          : c
       let reallyLongName =
         a ? longTruePart : longFalsePart
       let reallyLongName =

--- a/Tests/SwiftFormatPrettyPrintTests/TryCatchTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/TryCatchTests.swift
@@ -23,26 +23,14 @@ public class TryCatchTests: PrettyPrintTestCase {
       """
       do { foo() } catch { bar() }
 
-      do {
-        try thisFuncMightFail()
-      } catch error1 {
-        print("Nope")
-      }
+      do { try thisFuncMightFail() } catch error1 { print("Nope") }
 
-      do {
-        try thisFuncMightFail()
-      } catch error1 {
-        print("Nope")
-      } catch error2(let someVar) {
+      do { try thisFuncMightFail() } catch error1 { print("Nope") } catch error2(let someVar) {
         print(someVar)
         print("Don't do it!")
       }
 
-      do {
-        try thisFuncMightFail()
-      } catch is ABadError{
-        print("Nope")
-      }
+      do { try thisFuncMightFail() } catch is ABadError{ print("Nope") }
       """
 
     let expected =
@@ -85,15 +73,21 @@ public class TryCatchTests: PrettyPrintTestCase {
 
     let expected =
       """
-      do { try thisFuncMightFail() }
+      do {
+        try thisFuncMightFail()
+      }
       catch error1 where error1 is ErrorType {
         print("Nope")
       }
 
-      do { try thisFuncMightFail() }
+      do {
+        try thisFuncMightFail()
+      }
       catch error1
       where error1 is LongerErrorType
-      { print("Nope") }
+      {
+        print("Nope")
+      }
 
       """
 


### PR DESCRIPTION
This may not be perfect to handle all cases, but it's a step in that direction.

The only weird cases are situations like this:

```swift
let c = d
  as Int
```

which break more aggressively if we throw in discretionary line breaks:

```swift
let c =
  d
  as Int
```

We're still "preserving the line break the user put there", but we're also inserting a new one "unnecessarily" because the group surrounding the RHS of the equal sign (`d as Int`) is now so large due to the max-line-length break at the discretionary newline that it causes the break before it to fire.

I'm not sure what to do about that, except to remove the group around the RHS. Maybe that _is_ the right thing to do in this case?