### PR TITLE
Make line break before closing paren discretionary.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -586,7 +586,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
     after(
       node.leftParen,
       tokens: .break(size: 0, offset: 2), .open(.consistent, 0), .break(size: 0),
-        .open(.consistent, 0)
+        .open(.inconsistent, 0)
     )
     before(node.rightParen, tokens: .close, .break(size: 0, offset: -2), .close)
     super.visit(node)

--- a/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
@@ -37,8 +37,7 @@ public class ClosureExprTests: PrettyPrintTestCase {
         param1: 123,
         closure: { s1, s2, s3 in
           return s1
-        }
-      )
+        })
       funcCall(closure: {
         (s1: String, s2: String) -> Bool in
         return s1 > s2

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
@@ -18,8 +18,7 @@ public class FunctionCallTests: PrettyPrintTestCase {
         var1: 123,
         var2: "abc",
         var3: Bool,
-        var4: (1, 2, 3)
-      )
+        var4: (1, 2, 3))
       let a = myFunc(var1, var2, var3)
       let a = myFunc(
         var1,
@@ -27,20 +26,51 @@ public class FunctionCallTests: PrettyPrintTestCase {
         var3,
         var4,
         var5,
-        var6
-      )
+        var6)
       let a = myFunc(
         var1: 123,
         var2: someFun(
           var1: "abc",
           var2: 123,
           var3: Bool,
-          var4: 1.23
-        )
-      )
+          var4: 1.23))
 
       """
 
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
+
+  public func testDiscretionaryLineBreakBeforeClosingParenthesis() {
+    let input =
+      """
+      let a = myFunc(
+        var1: 123,
+        var2: "abc"
+      )
+      """
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 45)
+  }
+  
+  public func testDiscretionaryLineBreaksAreSelfCorrecting() {
+    // A discretionary line break should never permit a violation of the rule that says,
+    // effectively, "if a closing delimiter does not fit on the same line as its matching open
+    // delimiter, then the open delimiter is the last token on that line" (which is implemented in
+    // Oppen using consistent breaking groups). The line break we insert, if working correctly,
+    // should force the entire group to be moved down as we want.
+    let input =
+      """
+      let a = myFunc(var1: 123, var2: "abc"
+      )
+      """
+
+    let expected =
+      """
+      let a = myFunc(
+        var1: 123,
+        var2: "abc"
+      )
+
+      """
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
   }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/TupleDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/TupleDeclTests.swift
@@ -6,7 +6,6 @@ public class TupleDeclTests: PrettyPrintTestCase {
       let a: (Int, Int, Int) = (1, 2, 3)
       let a = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
       let a = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
-      let a = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,)
       """
 
     let expected =
@@ -17,32 +16,8 @@ public class TupleDeclTests: PrettyPrintTestCase {
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10
       )
       let a = (
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
         12
-      )
-      let a = (
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
       )
 
       """


### PR DESCRIPTION
This change also ended up hitting tuples in an interesting way, so I took the opportunity to make them inconsistent breaking. I'll do dictionaries and arrays in a follow-up PR. I also removed an invalid test case (tuples can't have trailing commas).

That being said, this could use a sanity check.