### PR TITLE
Improve the formatter configuration.

### DIFF
--- a/Sources/SwiftFormatConfiguration/Indent.swift
+++ b/Sources/SwiftFormatConfiguration/Indent.swift
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Represents an indentation unit that is applied to lines that are pretty-printed.
+public enum Indent: Hashable, Codable {
+
+  /// An indentation unit equal to the given number of tab characters.
+  ///
+  /// This value is independent of the actual tab width, which is set separately in the
+  /// `Configuration`.
+  case tabs(Int)
+
+  /// An indentation unit equal to the given number of spaces.
+  case spaces(Int)
+
+  private enum CodingKeys: CodingKey {
+    case tabs
+    case spaces
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let spacesCount = try container.decodeIfPresent(Int.self, forKey: .spaces)
+    let tabsCount = try container.decodeIfPresent(Int.self, forKey: .tabs)
+
+    if spacesCount != nil && tabsCount != nil {
+      throw DecodingError.dataCorrupted(DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Only one of \"tabs\" or \"spaces\" may be specified"))
+    }
+    if let spacesCount = spacesCount {
+      self = .spaces(spacesCount)
+      return
+    }
+    if let tabsCount = tabsCount {
+      self = .tabs(tabsCount)
+      return
+    }
+
+    throw DecodingError.dataCorrupted(DecodingError.Context(
+      codingPath: decoder.codingPath,
+      debugDescription: "One of \"tabs\" or \"spaces\" must be specified"))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case .tabs(let count):
+      try container.encode(count, forKey: .tabs)
+    case .spaces(let count):
+      try container.encode(count, forKey: .spaces)
+    }
+  }
+
+  /// Returns the number of units (tabs or spaces) that this indent represents.
+  ///
+  /// Note that this does _not_ represent the physical number of spaces occupied by the indentation.
+  public var count: Int {
+    switch self {
+    case .spaces(let count):
+      return count
+    case .tabs(let count):
+      return count
+    }
+  }
+}

--- a/Sources/SwiftFormatPrettyPrint/Indent+Length.swift
+++ b/Sources/SwiftFormatPrettyPrint/Indent+Length.swift
@@ -14,7 +14,7 @@ import SwiftFormatConfiguration
 
 extension Indent {
   var character: Character {
-    switch kind {
+    switch self {
     case .tabs: return "\t"
     case .spaces: return " "
     }
@@ -25,9 +25,9 @@ extension Indent {
   }
 
   func length(in configuration: Configuration) -> Int {
-    switch kind {
-    case .spaces: return count
-    case .tabs: return count * configuration.tabWidth
+    switch self {
+    case .spaces(let count): return count
+    case .tabs(let count): return count * configuration.tabWidth
     }
   }
 }

--- a/Sources/swift-format/Run.swift
+++ b/Sources/swift-format/Run.swift
@@ -20,14 +20,15 @@ import SwiftSyntax
 /// Runs the linting pipeline over the provided source file.
 ///
 /// If there were any lint diagnostics emitted, this function returns a non-zero exit code.
+/// - Parameter configuration: The `Configuration` that contains user-specific settings.
 /// - Parameter path: The absolute path to the source file to be linted.
 /// - Returns: Zero if there were no lint errors, otherwise a non-zero number.
-public func lintMain(path: String) -> Int {
+public func lintMain(configuration: Configuration, path: String) -> Int {
   let url = URL(fileURLWithPath: path)
   let engine = makeDiagnosticEngine()
 
   let context = Context(
-    configuration: Configuration(),
+    configuration: configuration,
     diagnosticEngine: engine,
     fileURL: url
   )
@@ -49,11 +50,13 @@ public func lintMain(path: String) -> Int {
 
 /// Runs the formatting pipeline over the provided source file.
 ///
+/// - Parameter configuration: The `Configuration` that contains user-specific settings.
 /// - Parameter path: The absolute path to the source file to be linted.
 /// - Returns: Zero if there were no lint errors, otherwise a non-zero number.
-public func formatMain(path: String, prettyPrint: Bool, printTokenStream: Bool) -> Int {
+public func formatMain(
+  configuration: Configuration, path: String, prettyPrint: Bool, printTokenStream: Bool
+) -> Int {
   let url = URL(fileURLWithPath: path)
-  let configuration = Configuration()
   let context = Context(configuration: configuration, diagnosticEngine: nil, fileURL: url)
 
   let pipeline = FormatPipeline(context: context)

--- a/Sources/swift-format/main.swift
+++ b/Sources/swift-format/main.swift
@@ -20,12 +20,14 @@ import Utility
 enum Mode: String, Codable, ArgumentKind {
   case format
   case lint
+  case dumpConfiguration = "dump-configuration"
   case version
 
   static var completion: ShellCompletion {
     return .values([
       ("format", "Format the provided files."),
       ("lint", "Lint the provided files."),
+      ("dump-configuration", "Dump the default configuration as JSON to standard output."),
     ])
   }
 
@@ -38,7 +40,7 @@ enum Mode: String, Codable, ArgumentKind {
 }
 
 struct CommandLineOptions: Codable {
-  var configurationPath = ""
+  var configurationPath: String? = nil
   var paths: [String] = []
   var verboseLevel = 0
   var mode: Mode = .format
@@ -56,7 +58,7 @@ func processArguments(commandName: String, _ arguments: [String]) -> CommandLine
       option: "--mode",
       shortName: "-m",
       kind: Mode.self,
-      usage: "The mode to run swift-format in. Either 'format' or 'lint'."
+      usage: "The mode to run swift-format in. Either 'format', 'lint', or 'dump-configuration'."
   )) {
     $0.mode = $1
   }
@@ -73,6 +75,7 @@ func processArguments(commandName: String, _ arguments: [String]) -> CommandLine
     positional: parser.add(
       positional: "filenames or paths",
       kind: [String].self,
+      optional: true,
       strategy: .upToNextOption,
       usage: "One or more input filenames",
       completion: .filename
@@ -96,6 +99,14 @@ func processArguments(commandName: String, _ arguments: [String]) -> CommandLine
   )) {
     $0.printTokenStream = $1
   }
+  binder.bind(
+    option: parser.add(
+      option: "--configuration",
+      kind: String.self,
+      usage: "The path to a JSON file containing the configuration of the linter/formatter."
+  )) {
+    $0.configurationPath = $1
+  }
 
   var opts = CommandLineOptions()
   do {
@@ -115,8 +126,10 @@ func main(_ arguments: [String]) -> Int32 {
   switch options.mode {
   case .format:
     var ret = 0
+    let configuration = decodedConfiguration(fromFileAtPath: options.configurationPath)
     for path in options.paths {
       ret |= formatMain(
+        configuration: configuration,
         path: path,
         prettyPrint: options.prettyPrint,
         printTokenStream: options.printTokenStream
@@ -125,13 +138,65 @@ func main(_ arguments: [String]) -> Int32 {
     return Int32(ret)
   case .lint:
     var ret = 0
+    let configuration = decodedConfiguration(fromFileAtPath: options.configurationPath)
     for path in options.paths {
-      ret |= lintMain(path: path)
+      ret |= lintMain(configuration: configuration, path: path)
     }
     return Int32(ret)
+  case .dumpConfiguration:
+    dumpDefaultConfiguration()
+    return 0
   case .version:
     print("0.0.1") // TODO(abl): Something fancy based on the git hash
     return 0
+  }
+}
+
+/// Loads and returns a `Configuration` from the given JSON file if it is found and is valid. If the
+/// file does not exist or there was an error decoding it, the program exits with a non-zero exit
+/// code.
+private func decodedConfiguration(fromFileAtPath path: String?) -> Configuration {
+  if let path = path {
+    do {
+      let url = URL(fileURLWithPath: path)
+      let data = try Data(contentsOf: url)
+      return try JSONDecoder().decode(Configuration.self, from: data)
+    }
+    catch {
+      // TODO: Improve error message, write to stderr.
+      print("Could not load configuration at \(path): \(error)")
+      exit(1)
+    }
+  }
+  else {
+    return Configuration()
+  }
+}
+
+/// Dumps the default configuration as JSON to standard output.
+private func dumpDefaultConfiguration() {
+  let configuration = Configuration()
+  do {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted]
+    if #available(macOS 10.13, *) {
+      encoder.outputFormatting.insert(.sortedKeys)
+    }
+
+    let data = try encoder.encode(configuration)
+    guard let jsonString = String(data: data, encoding: .utf8) else {
+      // This should never happen, but let's make sure we fail more gracefully than crashing, just
+      // in case.
+      // TODO: Improve error message, write to stderr.
+      print("Could not dump the default configuration: the JSON was not valid UTF-8")
+      exit(1)
+    }
+    print(jsonString)
+  }
+  catch {
+    // TODO: Improve error message, write to stderr.
+    print("Could not dump the default configuration: \(error)")
+    exit(1)
   }
 }
 


### PR DESCRIPTION
- Add a `--configuration` option that lets the user pass the path to a
  JSON file that will be loaded instead of the default configuration.
- Add a new mode (`--mode=dump-configuration`) that dumps the default
  configuration as JSON to standard output, so users can start with
  that and edit it.
- Make `Indent` an enum instead of a struct.
- Manually write the decode/encode methods (sigh) so that values can
  be omitted from the JSON (by default, decoding throws an error if
  a value is missing, even if the default value is present in the
  property initializer).