### PR TITLE
Fix spacing for attributed types

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -1054,6 +1054,7 @@ private final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: AttributedTypeSyntax) {
+    arrangeAttributeList(node.attributes)
     after(node.specifier, tokens: .break)
     super.visit(node)
   }

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
@@ -525,4 +525,31 @@ public class FunctionDeclTests: PrettyPrintTestCase {
       """
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 23)
   }
+
+  public func testAttributedTypes() {
+    let input =
+      """
+      func MyFun(myvar: @escaping MyType)
+
+      func MyFun(myvar1: Int, myvar2: Double, myvar3: @escaping MyType) -> Bool {
+        // do stuff
+        return false
+      }
+      """
+
+    let expected =
+      """
+      func MyFun(myvar: @escaping MyType)
+
+      func MyFun(
+        myvar1: Int, myvar2: Double,
+        myvar3: @escaping MyType
+      ) -> Bool {
+        // do stuff
+        return false
+      }
+
+      """
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 35)
+  }
 }


### PR DESCRIPTION
The spacing after the `@` token was not getting printed. e.g. `@escaping MyType` -> `@escapingMyType`.