### PR TITLE
Enable the pretty-printer pass by default.

### DIFF
--- a/Sources/swift-format/DebugOptions.swift
+++ b/Sources/swift-format/DebugOptions.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Advanced options that are useful when debugging and developing the formatter, but are otherwise
+/// not meant for general use.
+struct DebugOptions: OptionSet {
+
+  /// Disables the pretty-printer pass entirely, executing only the syntax-transforming rules in the
+  /// pipeline.
+  static let disablePrettyPrint = DebugOptions(rawValue: 1 << 0)
+
+  /// Dumps a verbose representation of the raw pretty-printer token stream.
+  static let dumpTokenStream = DebugOptions(rawValue: 1 << 1)
+
+  let rawValue: Int
+
+  init(rawValue: Int) { self.rawValue = rawValue }
+
+  /// Inserts or removes the given element from the option set, based on the value of `enabled`.
+  mutating func set(_ element: Element, enabled: Bool) {
+    if enabled { insert(element) } else { remove(element) }
+  }
+}

--- a/Sources/swift-format/Run.swift
+++ b/Sources/swift-format/Run.swift
@@ -23,7 +23,7 @@ import SwiftSyntax
 /// - Parameter configuration: The `Configuration` that contains user-specific settings.
 /// - Parameter path: The absolute path to the source file to be linted.
 /// - Returns: Zero if there were no lint errors, otherwise a non-zero number.
-public func lintMain(configuration: Configuration, path: String) -> Int {
+func lintMain(configuration: Configuration, path: String) -> Int {
   let url = URL(fileURLWithPath: path)
   let engine = makeDiagnosticEngine()
 
@@ -50,11 +50,13 @@ public func lintMain(configuration: Configuration, path: String) -> Int {
 
 /// Runs the formatting pipeline over the provided source file.
 ///
-/// - Parameter configuration: The `Configuration` that contains user-specific settings.
-/// - Parameter path: The absolute path to the source file to be linted.
+/// - Parameters:
+///   - configuration: The `Configuration` that contains user-specific settings.
+///   - path: The absolute path to the source file to be formatted.
+///   - debugOptions: The set containing any debug options that were supplied on the command line.
 /// - Returns: Zero if there were no lint errors, otherwise a non-zero number.
-public func formatMain(
-  configuration: Configuration, path: String, prettyPrint: Bool, printTokenStream: Bool
+func formatMain(
+  configuration: Configuration, path: String, debugOptions: DebugOptions
 ) -> Int {
   let url = URL(fileURLWithPath: path)
   let context = Context(configuration: configuration, diagnosticEngine: nil, fileURL: url)
@@ -68,7 +70,7 @@ public func formatMain(
     // version of visit(_: SourceFileSyntax), which will not run the pipeline properly.
     let formatted = pipeline.visit(file as Syntax)
 
-    if prettyPrint {
+    if !debugOptions.contains(.disablePrettyPrint) {
       // We create a different context here because we only want diagnostics from the pretty printer
       // phase when formatting.
       let prettyPrintContext = Context(
@@ -79,8 +81,7 @@ public func formatMain(
       let printer = PrettyPrinter(
         context: prettyPrintContext,
         node: formatted,
-        printTokenStream: printTokenStream
-      )
+        printTokenStream: debugOptions.contains(.dumpTokenStream))
       print(printer.prettyPrint(), terminator: "")
     } else {
       print(formatted.description, terminator: "")


### PR DESCRIPTION
It can be disabled (intended for development/debugging purposes only)
using the `--debug-disable-pretty-print` option.

This change also renames `--print-token-stream` to
`--debug-dump-token-stream`; going forward, we should namespace all
options intended for debugging with the prefix `--debug-*`.

These debugging options intentionally have no "usage" strings, which
hides them from the `--help` screen. In a future PR, we can update the
README to mention them (it needs a bigger overhaul that I don't want to
include in this PR).