### PR TITLE
Fix trailing line comments after verbatim tokens

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormatPrettyPrint/TokenStreamCreator.swift
@@ -93,9 +93,15 @@ private final class TokenStreamCreator: SyntaxVisitor {
       tokens += before
     }
     appendToken(.verbatim(Verbatim(text: node.description)))
-    if let lastToken = node.lastToken, let afterGroups = afterMap[lastToken] {
-      for after in afterGroups.reversed() {
-        tokens += after
+    if let lastToken = node.lastToken {
+      // Extract any comments that trail the verbatim block since they belong to the next syntax
+      // token. Leading comments don't need special handling since they belong to the current node,
+      // and will get printed.
+      extractTrailingComment(lastToken)
+      if let afterGroups = afterMap[lastToken] {
+        for after in afterGroups.reversed() {
+          tokens += after
+        }
       }
     }
   }

--- a/Tests/SwiftFormatPrettyPrintTests/UnknownStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/UnknownStmtTests.swift
@@ -110,4 +110,19 @@ public class UnknownStmtTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
   }
+
+  public func testUnknownStmtWithTrailingComment() {
+    let input =
+      """
+      struct MyStruct {
+        #if swift(>=4.2)
+          // Do stuff here
+        #endif  // trailing comment
+
+        let someMemberVar: Int
+      }
+      """
+
+    assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 45)
+  }
 }


### PR DESCRIPTION
We weren't checking for trailing line comments after verbatim tokens, so they were not getting printed.