### PR TITLE
Allow breaks to ignore discretionary newlines.

### DIFF
--- a/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormatPrettyPrint/PrettyPrint.swift
@@ -193,7 +193,7 @@ public class PrettyPrinter {
 
     // Create a line break if needed. Calculate the indentation required and adjust spaceRemaining
     // accordingly.
-    case .break(let kind, let size):
+    case .break(let kind, let size, _):
       lastBreakKind = kind
       var mustBreak = forceBreakStack.last ?? false
       var isContinuation = false
@@ -346,7 +346,7 @@ public class PrettyPrinter {
 
       // Break lengths are equal to its size plus the token or group following it. Calculate the
       // length of any prior break tokens.
-      case .break(_, let size):
+      case .break(_, let size, _):
         if let index = delimIndexStack.last, case .break = tokens[index] {
           lengths[index] += total
           delimIndexStack.removeLast()
@@ -436,9 +436,11 @@ public class PrettyPrinter {
       printDebugIndent()
       print("[SYNTAX \"\(syntax)\" Length: \(length)]")
 
-    case .break(let kind, let size):
+    case .break(let kind, let size, let ignoresDiscretionary):
       printDebugIndent()
-      print("[BREAK Kind: \(kind) Size: \(size) Length: \(length)]")
+      print(
+        "[BREAK Kind: \(kind) Size: \(size) Length: \(length) "
+          + "Ignores Discretionary NL: \(ignoresDiscretionary)]")
 
     case .open(let breakstyle):
       printDebugIndent()

--- a/Sources/SwiftFormatPrettyPrint/Token.swift
+++ b/Sources/SwiftFormatPrettyPrint/Token.swift
@@ -108,7 +108,7 @@ enum Token {
   case syntax(String)
   case open(GroupBreakStyle)
   case close
-  case `break`(BreakKind, size: Int)
+  case `break`(BreakKind, size: Int, ignoresDiscretionary: Bool)
   case space(size: Int)
   case newlines(Int, discretionary: Bool)
   case comment(Comment, wasEndOfLine: Bool)
@@ -126,9 +126,9 @@ enum Token {
 
   static let space = Token.space(size: 1)
 
-  static let `break` = Token.break(.continue, size: 1)
-  static func `break`(_ kind: BreakKind) -> Token {
-    return .break(kind, size: 1)
+  static let `break` = Token.break(.continue, size: 1, ignoresDiscretionary: false)
+  static func `break`(_ kind: BreakKind, size: Int = 1) -> Token {
+    return .break(kind, size: size, ignoresDiscretionary: false)
   }
 
   static func verbatim(text: String) -> Token {

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
@@ -552,4 +552,33 @@ public class FunctionDeclTests: PrettyPrintTestCase {
       """
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 35)
   }
+
+  public func testRemovesLineBreakBeforeOpenBraceUnlessAbsolutelyNecessary() {
+    let input =
+      """
+      func foo(bar: Int)
+      {
+        baz()
+      }
+
+      func foo(longer: Int)
+      {
+        baz()
+      }
+      """
+
+    let expected =
+      """
+      func foo(bar: Int) {
+        baz()
+      }
+
+      func foo(longer: Int)
+      {
+        baz()
+      }
+
+      """
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 21)
+  }
 }


### PR DESCRIPTION
Previously, discretionary newlines could appear anywhere that a break was
allowed. Some breaks, however, exist only as "last resorts" to allow a
line break to occur when there is no other way to break the tokens before
it. To handle this, we add a flag to breaks that allows them to discard
the user's newline unless that last resort behavior occurs.