### PR TITLE
Update cmark submodule to latest version.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,7 @@ let package = Package(
         // We must exclude main.c or SwiftPM will treat this target as an executable target instead
         // of a library, and we won't be able to import it from the CommonMark Swift module.
         "cmark/src/main.c",
+        "cmark/test",
       ]
     ),
     .target(name: "CommonMark", dependencies: ["CCommonMark"]),

--- a/Sources/CommonMark/CMarkInterop.swift
+++ b/Sources/CommonMark/CMarkInterop.swift
@@ -44,12 +44,10 @@ fileprivate func makeNode(from cNode: OpaquePointer) -> MarkdownNode {
       children: makeNodes(fromChildrenOf: cNode) as! [InlineContent],
       sourceRange: sourceRange)
   case CMARK_NODE_HEADING:
-    node = HeaderNode(
-      level: HeaderNode.Level(rawValue: numericCast(cmark_node_get_heading_level(cNode)))!,
+    node = HeadingNode(
+      level: HeadingNode.Level(rawValue: numericCast(cmark_node_get_heading_level(cNode)))!,
       children: makeNodes(fromChildrenOf: cNode) as! [InlineContent],
       sourceRange: sourceRange)
-  case CMARK_NODE_THEMATIC_BREAK:
-    node = HorizontalRuleNode(sourceRange: sourceRange)
   case CMARK_NODE_HTML_BLOCK:
     node = HTMLBlockNode(
       literalContent: String(cString: cmark_node_get_literal(cNode)),
@@ -106,6 +104,8 @@ fileprivate func makeNode(from cNode: OpaquePointer) -> MarkdownNode {
     node = TextNode(
       literalContent: String(cString: cmark_node_get_literal(cNode)),
       sourceRange: sourceRange)
+  case CMARK_NODE_THEMATIC_BREAK:
+    node = ThematicBreakNode(sourceRange: sourceRange)
   default:
     fatalError("Unexpected node type \(type) encountered")
   }
@@ -180,8 +180,7 @@ extension PrimitiveNode: CMarkNodeConvertible {
     case .codeBlock(let node): return node.makeCNode()
     case .document(let node): return node.makeCNode()
     case .emphasis(let node): return node.makeCNode()
-    case .header(let node): return node.makeCNode()
-    case .horizontalRule(let node): return node.makeCNode()
+    case .heading(let node): return node.makeCNode()
     case .htmlBlock(let node): return node.makeCNode()
     case .image(let node): return node.makeCNode()
     case .inlineCode(let node): return node.makeCNode()
@@ -194,6 +193,7 @@ extension PrimitiveNode: CMarkNodeConvertible {
     case .softBreak(let node): return node.makeCNode()
     case .strong(let node): return node.makeCNode()
     case .text(let node): return node.makeCNode()
+    case .thematicBreak(let node): return node.makeCNode()
     }
   }
 }
@@ -239,7 +239,7 @@ extension HTMLBlockNode: CMarkNodeConvertible {
   }
 }
 
-extension HeaderNode: CMarkNodeConvertible {
+extension HeadingNode: CMarkNodeConvertible {
 
   func makeCNode() -> OpaquePointer {
     let cNode = cmark_node_new(CMARK_NODE_HEADING)!
@@ -248,13 +248,6 @@ extension HeaderNode: CMarkNodeConvertible {
       cmark_node_append_child(cNode, child.primitiveRepresentation.makeCNode())
     }
     return cNode
-  }
-}
-
-extension HorizontalRuleNode: CMarkNodeConvertible {
-
-  func makeCNode() -> OpaquePointer {
-    return cmark_node_new(CMARK_NODE_THEMATIC_BREAK)!
   }
 }
 
@@ -386,5 +379,12 @@ extension TextNode: CMarkNodeConvertible {
     let cNode = cmark_node_new(CMARK_NODE_TEXT)!
     cmark_node_set_literal(cNode, literalContent)
     return cNode
+  }
+}
+
+extension ThematicBreakNode: CMarkNodeConvertible {
+
+  func makeCNode() -> OpaquePointer {
+    return cmark_node_new(CMARK_NODE_THEMATIC_BREAK)!
   }
 }

--- a/Sources/CommonMark/CMarkInterop.swift
+++ b/Sources/CommonMark/CMarkInterop.swift
@@ -43,14 +43,14 @@ fileprivate func makeNode(from cNode: OpaquePointer) -> MarkdownNode {
     node = EmphasisNode(
       children: makeNodes(fromChildrenOf: cNode) as! [InlineContent],
       sourceRange: sourceRange)
-  case CMARK_NODE_HEADER:
+  case CMARK_NODE_HEADING:
     node = HeaderNode(
-      level: HeaderNode.Level(rawValue: numericCast(cmark_node_get_header_level(cNode)))!,
+      level: HeaderNode.Level(rawValue: numericCast(cmark_node_get_heading_level(cNode)))!,
       children: makeNodes(fromChildrenOf: cNode) as! [InlineContent],
       sourceRange: sourceRange)
-  case CMARK_NODE_HRULE:
+  case CMARK_NODE_THEMATIC_BREAK:
     node = HorizontalRuleNode(sourceRange: sourceRange)
-  case CMARK_NODE_HTML:
+  case CMARK_NODE_HTML_BLOCK:
     node = HTMLBlockNode(
       literalContent: String(cString: cmark_node_get_literal(cNode)),
       sourceRange: sourceRange)
@@ -60,7 +60,7 @@ fileprivate func makeNode(from cNode: OpaquePointer) -> MarkdownNode {
       title: String(cString: cmark_node_get_title(cNode)),
       children: makeNodes(fromChildrenOf: cNode) as! [InlineContent],
       sourceRange: sourceRange)
-  case CMARK_NODE_INLINE_HTML:
+  case CMARK_NODE_HTML_INLINE:
     node = InlineHTMLNode(
       literalContent: String(cString: cmark_node_get_literal(cNode)),
       sourceRange: sourceRange)
@@ -233,7 +233,7 @@ extension EmphasisNode: CMarkNodeConvertible {
 extension HTMLBlockNode: CMarkNodeConvertible {
 
   func makeCNode() -> OpaquePointer {
-    let cNode = cmark_node_new(CMARK_NODE_HTML)!
+    let cNode = cmark_node_new(CMARK_NODE_HTML_BLOCK)!
     cmark_node_set_literal(cNode, literalContent)
     return cNode
   }
@@ -242,8 +242,8 @@ extension HTMLBlockNode: CMarkNodeConvertible {
 extension HeaderNode: CMarkNodeConvertible {
 
   func makeCNode() -> OpaquePointer {
-    let cNode = cmark_node_new(CMARK_NODE_HEADER)!
-    cmark_node_set_header_level(cNode, numericCast(level.rawValue))
+    let cNode = cmark_node_new(CMARK_NODE_HEADING)!
+    cmark_node_set_heading_level(cNode, numericCast(level.rawValue))
     for child in children {
       cmark_node_append_child(cNode, child.primitiveRepresentation.makeCNode())
     }
@@ -254,7 +254,7 @@ extension HeaderNode: CMarkNodeConvertible {
 extension HorizontalRuleNode: CMarkNodeConvertible {
 
   func makeCNode() -> OpaquePointer {
-    return cmark_node_new(CMARK_NODE_HRULE)!
+    return cmark_node_new(CMARK_NODE_THEMATIC_BREAK)!
   }
 }
 
@@ -283,7 +283,7 @@ extension InlineCodeNode: CMarkNodeConvertible {
 extension InlineHTMLNode: CMarkNodeConvertible {
 
   func makeCNode() -> OpaquePointer {
-    let cNode = cmark_node_new(CMARK_NODE_INLINE_HTML)!
+    let cNode = cmark_node_new(CMARK_NODE_HTML_INLINE)!
     cmark_node_set_literal(cNode, literalContent)
     return cNode
   }

--- a/Sources/CommonMark/HeadingNode.swift
+++ b/Sources/CommonMark/HeadingNode.swift
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A block element that represents a section header.
-public struct HeaderNode: BlockContent {
+/// A block element that represents a section heading.
+public struct HeadingNode: BlockContent {
 
-  /// The level of a header, which describes its position in the hierarchy of a document and the
-  /// size at which the header is rendered.
+  /// The level of a heading, which describes its position in the hierarchy of a document and the
+  /// size at which the heading is rendered.
   public enum Level: Int {
     case h1 = 1
     case h2 = 2
@@ -24,7 +24,7 @@ public struct HeaderNode: BlockContent {
     case h6 = 6
   }
 
-  /// The level of the header.
+  /// The level of the heading.
   public let level: Level
 
   /// The children of the receiver.
@@ -32,12 +32,12 @@ public struct HeaderNode: BlockContent {
 
   public let sourceRange: Range<SourceLocation>?
 
-  public var primitiveRepresentation: PrimitiveNode { return .header(self) }
+  public var primitiveRepresentation: PrimitiveNode { return .heading(self) }
 
-  /// Creates a new header node.
+  /// Creates a new heading node.
   ///
   /// - Parameters:
-  ///   - level: The level of the header. If omitted, `.h1` is used.
+  ///   - level: The level of the heading. If omitted, `.h1` is used.
   ///   - children: Inline content nodes that are children of the new node.
   ///   - sourceRange: The source range from which the node was parsed, if known.
   public init(
@@ -55,8 +55,8 @@ public struct HeaderNode: BlockContent {
   ///
   /// - Parameter level: The new level.
   /// - Returns: The new node.
-  public func replacingLevel(_ level: Level) -> HeaderNode {
-    return HeaderNode(level: level, children: children, sourceRange: sourceRange)
+  public func replacingLevel(_ level: Level) -> HeadingNode {
+    return HeadingNode(level: level, children: children, sourceRange: sourceRange)
   }
 
   /// Returns a new node equivalent to the receiver, but whose children have been replaced with the
@@ -64,8 +64,8 @@ public struct HeaderNode: BlockContent {
   ///
   /// - Parameter children: The new list of children.
   /// - Returns: The new node.
-  public func replacingChildren(_ children: [InlineContent]) -> HeaderNode {
-    return HeaderNode(level: level, children: children, sourceRange: sourceRange)
+  public func replacingChildren(_ children: [InlineContent]) -> HeadingNode {
+    return HeadingNode(level: level, children: children, sourceRange: sourceRange)
   }
 
   /// Returns a new node equivalent to the receiver, but whose source range has been replaced with
@@ -73,7 +73,7 @@ public struct HeaderNode: BlockContent {
   ///
   /// - Parameter sourceRange: The new source range.
   /// - Returns: The new node.
-  public func replacingSourceRange(_ sourceRange: Range<SourceLocation>?) -> HeaderNode {
-    return HeaderNode(children: children, sourceRange: sourceRange)
+  public func replacingSourceRange(_ sourceRange: Range<SourceLocation>?) -> HeadingNode {
+    return HeadingNode(children: children, sourceRange: sourceRange)
   }
 }

--- a/Sources/CommonMark/MarkdownRewriter.swift
+++ b/Sources/CommonMark/MarkdownRewriter.swift
@@ -36,8 +36,7 @@ open class MarkdownRewriter {
     case let castNode as CodeBlockNode: return visit(castNode)
     case let castNode as EmphasisNode: return visit(castNode)
     case let castNode as HTMLBlockNode: return visit(castNode)
-    case let castNode as HeaderNode: return visit(castNode)
-    case let castNode as HorizontalRuleNode: return visit(castNode)
+    case let castNode as HeadingNode: return visit(castNode)
     case let castNode as ImageNode: return visit(castNode)
     case let castNode as InlineCodeNode: return visit(castNode)
     case let castNode as InlineHTMLNode: return visit(castNode)
@@ -50,6 +49,7 @@ open class MarkdownRewriter {
     case let castNode as SoftBreakNode: return visit(castNode)
     case let castNode as StrongNode: return visit(castNode)
     case let castNode as TextNode: return visit(castNode)
+    case let castNode as ThematicBreakNode: return visit(castNode)
     case let castNode as BlockContent: return visit(extension: castNode)
     case let castNode as InlineContent: return visit(extension: castNode)
     default:
@@ -121,7 +121,7 @@ open class MarkdownRewriter {
     return node
   }
 
-  /// Called when a `HeaderNode` is visited, replacing it in the AST with the returned node.
+  /// Called when a `HeadingNode` is visited, replacing it in the AST with the returned node.
   ///
   /// The base class implementation of this method automatically visits the children of the node and
   /// returns a node whose children have been replaced by the results of that visitation. If you
@@ -129,18 +129,8 @@ open class MarkdownRewriter {
   ///
   /// - Parameter node: The node being visited.
   /// - Returns: The node that should replace the given node in the AST.
-  open func visit(_ node: HeaderNode) -> BlockContent {
+  open func visit(_ node: HeadingNode) -> BlockContent {
     return node.replacingChildren(visitAll(node.children))
-  }
-
-  /// Called when a `HorizontalRuleNode` is visited, replacing it in the AST with the returned node.
-  ///
-  /// The base class implementation of this method simply returns the same node.
-  ///
-  /// - Parameter node: The node being visited.
-  /// - Returns: The node that should replace the given node in the AST.
-  open func visit(_ node: HorizontalRuleNode) -> BlockContent {
-    return node
   }
 
   /// Called when a `ImageNode` is visited, replacing it in the AST with the returned node.
@@ -274,6 +264,16 @@ open class MarkdownRewriter {
   /// - Parameter node: The node being visited.
   /// - Returns: The node that should replace the given node in the AST.
   open func visit(_ node: TextNode) -> InlineContent {
+    return node
+  }
+
+  /// Called when a `ThematicBreakNode` is visited, replacing it in the AST with the returned node.
+  ///
+  /// The base class implementation of this method simply returns the same node.
+  ///
+  /// - Parameter node: The node being visited.
+  /// - Returns: The node that should replace the given node in the AST.
+  open func visit(_ node: ThematicBreakNode) -> BlockContent {
     return node
   }
 

--- a/Sources/CommonMark/MarkdownVisitor.swift
+++ b/Sources/CommonMark/MarkdownVisitor.swift
@@ -33,8 +33,7 @@ open class MarkdownVisitor {
     case let castNode as CodeBlockNode: visit(castNode)
     case let castNode as EmphasisNode: visit(castNode)
     case let castNode as HTMLBlockNode: visit(castNode)
-    case let castNode as HeaderNode: visit(castNode)
-    case let castNode as HorizontalRuleNode: visit(castNode)
+    case let castNode as HeadingNode: visit(castNode)
     case let castNode as ImageNode: visit(castNode)
     case let castNode as InlineCodeNode: visit(castNode)
     case let castNode as InlineHTMLNode: visit(castNode)
@@ -47,6 +46,7 @@ open class MarkdownVisitor {
     case let castNode as SoftBreakNode: visit(castNode)
     case let castNode as StrongNode: visit(castNode)
     case let castNode as TextNode: visit(castNode)
+    case let castNode as ThematicBreakNode: visit(castNode)
     default: visit(extension: node)
     }
     afterVisit(node)
@@ -104,22 +104,15 @@ open class MarkdownVisitor {
   /// - Parameter node: The node being visited.
   open func visit(_ node: HTMLBlockNode) {}
 
-  /// Called when a `HeaderNode` is visited.
+  /// Called when a `HeadingNode` is visited.
   ///
   /// The base class implementation of this method automatically visits the children of the node. If
   /// you override it, you must call `super.visit(node)` if you wish to visit the children as well.
   ///
   /// - Parameter node: The node being visited.
-  open func visit(_ node: HeaderNode) {
+  open func visit(_ node: HeadingNode) {
     visitAll(node.children)
   }
-
-  /// Called when a `HorizontalRuleNode` is visited.
-  ///
-  /// The base class implementation of this method does nothing.
-  ///
-  /// - Parameter node: The node being visited.
-  open func visit(_ node: HorizontalRuleNode) {}
 
   /// Called when a `ImageNode` is visited.
   ///
@@ -225,6 +218,13 @@ open class MarkdownVisitor {
   ///
   /// - Parameter node: The node being visited.
   open func visit(_ node: TextNode) {}
+
+  /// Called when a `ThematicBreakNode` is visited.
+  ///
+  /// The base class implementation of this method does nothing.
+  ///
+  /// - Parameter node: The node being visited.
+  open func visit(_ node: ThematicBreakNode) {}
 
   /// Visits a custom extension node.
   ///

--- a/Sources/CommonMark/PrimitiveNode.swift
+++ b/Sources/CommonMark/PrimitiveNode.swift
@@ -31,9 +31,7 @@ public enum PrimitiveNode {
 
   case emphasis(EmphasisNode)
 
-  case header(HeaderNode)
-
-  case horizontalRule(HorizontalRuleNode)
+  case heading(HeadingNode)
 
   case htmlBlock(HTMLBlockNode)
 
@@ -58,4 +56,6 @@ public enum PrimitiveNode {
   case strong(StrongNode)
 
   case text(TextNode)
+
+  case thematicBreak(ThematicBreakNode)
 }

--- a/Sources/CommonMark/ThematicBreakNode.swift
+++ b/Sources/CommonMark/ThematicBreakNode.swift
@@ -10,14 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A block element that represents a horizontal rule.
-public struct HorizontalRuleNode: BlockContent {
+/// A block element that represents a thematic break between large ranges of Markdown content (which
+/// is typically rendered as a horizontal rule).
+public struct ThematicBreakNode: BlockContent {
 
   public let sourceRange: Range<SourceLocation>?
 
-  public var primitiveRepresentation: PrimitiveNode { return .horizontalRule(self) }
+  public var primitiveRepresentation: PrimitiveNode { return .thematicBreak(self) }
 
-  /// Creates a new horizontal rule node.
+  /// Creates a new thematic break node.
   ///
   /// - Parameter sourceRange: The source range from which the node was parsed, if known.
   public init(sourceRange: Range<SourceLocation>? = nil) {
@@ -29,7 +30,7 @@ public struct HorizontalRuleNode: BlockContent {
   ///
   /// - Parameter sourceRange: The new source range.
   /// - Returns: The new node.
-  public func replacingSourceRange(_ sourceRange: Range<SourceLocation>?) -> HorizontalRuleNode {
-    return HorizontalRuleNode(sourceRange: sourceRange)
+  public func replacingSourceRange(_ sourceRange: Range<SourceLocation>?) -> ThematicBreakNode {
+    return ThematicBreakNode(sourceRange: sourceRange)
   }
 }

--- a/Tests/CommonMarkTests/MarkdownDocumentTest.swift
+++ b/Tests/CommonMarkTests/MarkdownDocumentTest.swift
@@ -50,26 +50,13 @@ final class MarkdownDocumentTest: XCTestCase {
       """)
   }
 
-  func testInitByParsing_header() {
+  func testInitByParsing_heading() {
     let document = MarkdownDocument(byParsing: "# Foo")
 
-    let header = document.children[0] as! HeaderNode
-    XCTAssertEqual(header.level, .h1)
-    let text = header.children[0] as! TextNode
+    let heading = document.children[0] as! HeadingNode
+    XCTAssertEqual(heading.level, .h1)
+    let text = heading.children[0] as! TextNode
     XCTAssertEqual(text.literalContent, "Foo")
-  }
-
-  func testInitByParsing_horizontalRule() {
-    let document = MarkdownDocument(byParsing: """
-      foo
-
-      ---
-
-      bar
-      """)
-
-    let rule = document.children[1] as? HorizontalRuleNode
-    XCTAssertNotNil(rule)
   }
 
   func testInitByParsing_image() {
@@ -172,6 +159,19 @@ final class MarkdownDocumentTest: XCTestCase {
     let paragraph = document.children[0] as! ParagraphNode
     let text = paragraph.children[0] as! TextNode
     XCTAssertEqual(text.literalContent, "basic")
+  }
+
+  func testInitByParsing_thematicBreak() {
+    let document = MarkdownDocument(byParsing: """
+      foo
+
+      ---
+
+      bar
+      """)
+
+    let rule = document.children[1] as? ThematicBreakNode
+    XCTAssertNotNil(rule)
   }
 }
 

--- a/Tests/CommonMarkTests/MarkdownRenderingTest.swift
+++ b/Tests/CommonMarkTests/MarkdownRenderingTest.swift
@@ -57,15 +57,15 @@ final class MarkdownRedneringTest: XCTestCase {
       """)
   }
 
-  func testStringRenderedUsing_header() {
+  func testStringRenderedUsing_heading() {
     let document = MarkdownDocument(
       children: [
-        HeaderNode(level: .h1, children: [TextNode(literalContent: "header 1")]),
-        HeaderNode(level: .h2, children: [TextNode(literalContent: "header 2")]),
-        HeaderNode(level: .h3, children: [TextNode(literalContent: "header 3")]),
-        HeaderNode(level: .h4, children: [TextNode(literalContent: "header 4")]),
-        HeaderNode(level: .h5, children: [TextNode(literalContent: "header 5")]),
-        HeaderNode(level: .h6, children: [TextNode(literalContent: "header 6")]),
+        HeadingNode(level: .h1, children: [TextNode(literalContent: "header 1")]),
+        HeadingNode(level: .h2, children: [TextNode(literalContent: "header 2")]),
+        HeadingNode(level: .h3, children: [TextNode(literalContent: "header 3")]),
+        HeadingNode(level: .h4, children: [TextNode(literalContent: "header 4")]),
+        HeadingNode(level: .h5, children: [TextNode(literalContent: "header 5")]),
+        HeadingNode(level: .h6, children: [TextNode(literalContent: "header 6")]),
       ])
     let rendered = document.string(renderedUsing: .commonMark)
     XCTAssertEqual(rendered, """
@@ -80,24 +80,6 @@ final class MarkdownRedneringTest: XCTestCase {
       ##### header 5
 
       ###### header 6
-
-      """)
-  }
-
-  func testStringRenderedUsing_horizontalRule() {
-    let document = MarkdownDocument(
-      children: [
-        ParagraphNode(children: [TextNode(literalContent: "First paragraph.")]),
-        HorizontalRuleNode(),
-        ParagraphNode(children: [TextNode(literalContent: "Second paragraph.")]),
-      ])
-    let rendered = document.string(renderedUsing: .commonMark)
-    XCTAssertEqual(rendered, """
-      First paragraph.
-
-      -----
-
-      Second paragraph.
 
       """)
   }
@@ -177,7 +159,7 @@ final class MarkdownRedneringTest: XCTestCase {
       ])
     let rendered = document.string(renderedUsing: .commonMark)
     XCTAssertEqual(rendered, """
-      Before the break.\\
+      Before the break.\u{0020}\u{0020}
       After the break.
 
       """)
@@ -215,9 +197,9 @@ final class MarkdownRedneringTest: XCTestCase {
       ])
     let rendered = document.string(renderedUsing: .commonMark)
     XCTAssertEqual(rendered, """
-      * item 1
-      * item 2
-      * item 3
+        - item 1
+        - item 2
+        - item 3
 
       """)
   }
@@ -300,6 +282,24 @@ final class MarkdownRedneringTest: XCTestCase {
     let rendered = document.string(renderedUsing: .commonMark)
     XCTAssertEqual(rendered, """
       Some text.
+
+      """)
+  }
+
+  func testStringRenderedUsing_thematicBreak() {
+    let document = MarkdownDocument(
+      children: [
+        ParagraphNode(children: [TextNode(literalContent: "First paragraph.")]),
+        ThematicBreakNode(),
+        ParagraphNode(children: [TextNode(literalContent: "Second paragraph.")]),
+      ])
+    let rendered = document.string(renderedUsing: .commonMark)
+    XCTAssertEqual(rendered, """
+      First paragraph.
+
+      -----
+
+      Second paragraph.
 
       """)
   }


### PR DESCRIPTION
The names of some of the node types changed, so I've updated the Swift versions to match. The new names are closer to the terms of art used in the Commonmark specification.