### PR TITLE
Use the pretty-printer output for whitespace linting

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,7 @@ let package = Package(
         "SwiftFormatCore",
         "SwiftFormatPrettyPrint",
         "SwiftFormatRules",
+        "SwiftFormatWhitespaceLinter",
         "SwiftSyntax",
       ]
     ),
@@ -55,6 +56,13 @@ let package = Package(
     .target(
       name: "SwiftFormatPrettyPrint",
       dependencies: ["SwiftFormatCore", "SwiftFormatConfiguration"]
+    ),
+    .target(
+      name: "SwiftFormatWhitespaceLinter",
+      dependencies: [
+        "SwiftFormatCore",
+        "SwiftSyntax",
+      ]
     ),
     .target(name: "generate-pipeline", dependencies: ["SwiftSyntax"]),
     .target(
@@ -85,6 +93,15 @@ let package = Package(
         "SwiftFormatCore",
         "SwiftFormatPrettyPrint",
         "SwiftFormatRules",
+        "SwiftSyntax",
+      ]
+    ),
+    .testTarget(
+      name: "SwiftFormatWhitespaceLinterTests",
+      dependencies: [
+        "SwiftFormatConfiguration",
+        "SwiftFormatCore",
+        "SwiftFormatWhitespaceLinter",
         "SwiftSyntax",
       ]
     ),

--- a/Sources/SwiftFormat/SwiftLinter.swift
+++ b/Sources/SwiftFormat/SwiftLinter.swift
@@ -13,6 +13,8 @@
 import Foundation
 import SwiftFormatConfiguration
 import SwiftFormatCore
+import SwiftFormatPrettyPrint
+import SwiftFormatWhitespaceLinter
 import SwiftSyntax
 
 /// Diagnoses and reports problems in Swift source code or syntax trees according to the Swift style
@@ -64,7 +66,15 @@ public final class SwiftLinter {
 
     pipeline.visit(syntax as Syntax)
 
-    // TODO: Extend the pretty printer to make it possible to lint spacing and breaking issues.
+    // Perform whitespace linting by comparing the input source text with the output of the
+    // pretty-printer.
+    let printer = PrettyPrinter(
+      context: context,
+      node: syntax,
+      printTokenStream: debugOptions.contains(.dumpTokenStream))
+    let formatted = printer.prettyPrint()
+    let ws = WhitespaceLinter(user: syntax.description, formatted: formatted, context: context)
+    ws.lint()
   }
 
   // TODO: Add an overload of `lint` that takes the source text directly.

--- a/Sources/SwiftFormatWhitespaceLinter/WhitespaceLinter.swift
+++ b/Sources/SwiftFormatWhitespaceLinter/WhitespaceLinter.swift
@@ -1,0 +1,342 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Formatter open source project.
+//
+// Copyright (c) 2018 Apple Inc. and the Swift Formatter project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Formatter project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftFormatCore
+import SwiftSyntax
+
+/// Emits linter errors for whitespace style violations by comparing the raw text of the input Swift
+/// code with formatted text.
+public struct WhitespaceLinter {
+
+  /// The text of the input source code to be linted.
+  let userText: String
+
+  /// The formatted version of `userText`.
+  let formattedText: String
+
+  /// The Context object containing the DiagnosticEngine.
+  let context: Context
+
+  /// Creates a new WhitespaceLinter with the given context.
+  ///
+  /// - Parameters:
+  ///   - user: The text of the Swift source code to be linted.
+  ///   - formatted: The formatted text to compare to `user`.
+  ///   - context: The context object containing the DiagnosticEngine instance we wish to use.
+  public init(user: String, formatted: String, context: Context) {
+    self.userText = user
+    self.formattedText = formatted
+    self.context = context
+  }
+
+  /// Perform whitespace linting.
+  public func lint() {
+    var userOffset = 0
+    var formOffset = 0
+    var isFirstCharater = true
+    var lastChar: Character?
+
+    repeat {
+      let userNext = nextCharacter(offset: userOffset, data: self.userText)
+      let formNext = nextCharacter(offset: formOffset, data: self.formattedText)
+
+      // `userText` and `formattedText` should only differ in their whitespace characters.
+      if userNext.char != formNext.char {
+        fatalError("Characters do not match")
+      }
+
+      lastChar = userNext.char
+
+      compareWhitespace(
+        userOffset: userOffset,
+        isFirstCharacter: isFirstCharater,
+        userWs: userNext.whitespace,
+        formattedWs: formNext.whitespace
+      )
+
+      userOffset = userNext.offset + 1
+      formOffset = formNext.offset + 1
+      isFirstCharater = false
+    } while lastChar != nil
+  }
+
+  /// Compare the whitespace buffers between the user text and formatted text, and emit linter
+  /// errors accordingly.
+  ///
+  /// Note: properly formatted whitespace will always be some number of newline characters
+  /// followed by some number of spaces in the absence of trailing whitespace (which the
+  /// pretty-printer ensures). e.g. "\n ", "\n\n  ", "\n", " ". The user's whitespace could have
+  /// spaces and newlines in any order. e.g. " \n ", "  \n", etc.
+  ///
+  /// - Parameters:
+  ///   - userOffset: The current non-whitespace character offset within the user text.
+  ///   - isFirstCharacter: Are we at the first character in the text?
+  ///   - userWs: The user leading whitespace buffer at the current character.
+  ///   - formattedWs: The formatted leading whitespace buffer at the current character.
+  func compareWhitespace(
+    userOffset: Int, isFirstCharacter: Bool, userWs: String, formattedWs: String
+  ) {
+    if userWs == formattedWs { return }
+
+    // e.g. "\n" -> ["", ""], and "" -> [""]
+    let userTokens = userWs.split(
+      separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    let formTokens = formattedWs.split(
+      separator: "\n", omittingEmptySubsequences: false).map(String.init)
+
+    checkForIndentationErrors(
+      userOffset: userOffset,
+      isFirstCharacter: isFirstCharacter,
+      user: userTokens,
+      form: formTokens)
+
+    checkForTrailingWhitespaceErrors(userOffset: userOffset, user: userTokens, form: formTokens)
+
+    checkForSpacingErrors(
+      userOffset: userOffset,
+      isFirstCharacter: isFirstCharacter,
+      user: userTokens,
+      form: formTokens)
+
+    checkForRemoveLineErrors(userOffset: userOffset, user: userTokens, form: formTokens)
+
+    checkForAddLineErrors(userOffset: userOffset, user: userTokens, form: formTokens)
+  }
+
+  /// Compare user and formatted whitespace buffers, and check for indentation errors.
+  ///
+  /// Example:
+  ///
+  ///     func myFun() {
+  ///     let a = 123  // Indentation error on this line
+  ///     }
+  ///
+  /// - Parameters:
+  ///   - userOffset: The current non-whitespace character offset within the user text.
+  ///   - isFirstCharacter: Are we at the first character in the text?
+  ///   - user: The tokenized user whitespace buffer.
+  ///   - form: The tokenized formatted whitespace buffer.
+  func checkForIndentationErrors(
+    userOffset: Int, isFirstCharacter: Bool, user: [String], form: [String]
+  ) {
+    guard form.count > 1 && user.count > 1 else {
+      // Ordinarily, we only look for indentation spacing following a newline. The first character
+      // of a file is a special case since it isn't preceded by any newlines.
+      if form.count == 1 && user.count == 1 && isFirstCharacter {
+        if form[0].count != user[0].count {
+          diagnose(.indentationError(form[0].count), line: 1, column: 1, utf8Offset: 0)
+        }
+      }
+      return
+    }
+    var offset = 0
+    for i in 0..<(user.count - 1) {
+      offset += user[i].count + 1
+    }
+    if form.last?.count != user.last?.count {
+      let pos = calculatePosition(offset: userOffset + offset, data: self.userText)
+      diagnose(
+        .indentationError(form.last!.count), line: pos.line, column: pos.column, utf8Offset: 0
+      )
+    }
+  }
+
+  /// Compare user and formatted whitespace buffers, and check for trailing whitespace.
+  ///
+  /// - Parameters:
+  ///   - userOffset: The current non-whitespace character offset within the user text.
+  ///   - user: The tokenized user whitespace buffer.
+  ///   - form: The tokenized formatted whitespace buffer.
+  func checkForTrailingWhitespaceErrors(userOffset: Int, user: [String], form: [String]) {
+    guard form.count > 1 && user.count > 1 else { return }
+    var offset = 0
+    for i in 0..<(user.count - 1) {
+      if user[i].count > 0 {
+        let pos = calculatePosition(offset: userOffset + offset, data: self.userText)
+        diagnose(.trailingWhitespaceError, line: pos.line, column: pos.column, utf8Offset: 0)
+      }
+      offset += user[i].count + 1
+    }
+  }
+
+  /// Compare user and formatted whitespace buffers, and check for spacing errors.
+  ///
+  /// Example:
+  ///
+  ///     let a : Int = 123  // Spacing error before the colon
+  ///
+  /// - Parameters:
+  ///   - userOffset: The current non-whitespace character offset within the user text.
+  ///   - isFirstCharacter: Are we at the first character in the text?
+  ///   - user: The tokenized user whitespace buffer.
+  ///   - form: The tokenized formatted whitespace buffer.
+  func checkForSpacingErrors(
+    userOffset: Int, isFirstCharacter: Bool, user: [String], form: [String]
+  ) {
+    // The spaces in front of the first character of a file are indentation and not spacing related.
+    guard form.count == 1 && user.count == 1 && !isFirstCharacter else { return }
+    if form[0].count != user[0].count {
+      let pos = calculatePosition(offset: userOffset, data: self.userText)
+      diagnose(.spacingError(form[0].count), line: pos.line, column: pos.column, utf8Offset: 0)
+    }
+  }
+
+  /// Compare user and formatted whitespace buffers, and check if linebreaks need to be removed.
+  ///
+  /// Example:
+  ///   Formatted:
+  ///
+  ///       func myfun() { return 123 }
+  ///
+  ///   User:
+  ///
+  ///       func myfun() {
+  ///         return 123  // this linebreak must be removed
+  ///       }  // this linebreak must be removed
+  ///
+  /// - Parameters:
+  ///   - userOffset: The current non-whitespace character offset within the user text.
+  ///   - user: The tokenized user whitespace buffer.
+  ///   - form: The tokenized formatted whitespace buffer.
+  func checkForRemoveLineErrors(userOffset: Int, user: [String], form: [String]) {
+    guard form.count < user.count else { return }
+    var offset = 0
+    for i in 0..<(user.count - form.count) {
+      let pos = calculatePosition(offset: userOffset + offset, data: self.userText)
+      diagnose(.removeLineError, line: pos.line, column: pos.column, utf8Offset: 0)
+      offset += user[i].count + 1
+    }
+  }
+
+  /// Compare user and formatted whitespace buffers, and check if additional line breaks need to be
+  /// added.
+  ///
+  /// Example:
+  ///   Formatted:
+  ///
+  ///       func myFun() {
+  ///         return 123
+  ///       }
+  ///
+  ///   User:
+  ///
+  ///       func myFun() { return 123 }  //  add linesbreaks before and after the return statement
+  ///
+  /// - Parameters:
+  ///   - userOffset: The current non-whitespace character offset within the user text.
+  ///   - user: The tokenized user whitespace buffer.
+  ///   - form: The tokenized formatted whitespace buffer.
+  func checkForAddLineErrors(userOffset: Int, user: [String], form: [String]) {
+    guard form.count > user.count else { return }
+    let pos = calculatePosition(offset: userOffset, data: self.userText)
+    diagnose(
+      .addLinesError(form.count - user.count), line: pos.line, column: pos.column, utf8Offset: 0
+    )
+  }
+
+  /// Find the next non-whitespace character in a given string, and any leading whitespace before
+  /// the character.
+  ///
+  /// If the character at `offset` is whitespace, we scan forward until we find a non-whitespace
+  /// character. We then return the new offset, the character we landed on, and a string containing
+  /// the character's leading whitespace.
+  ///
+  /// - Parameters:
+  ///   - offset: The printable character offset within the string.
+  ///   - data: The input string.
+  /// - Returns a tuple of the new offset, the non-whitespace character we landed on, and a string
+  ///   containing the leading whitespace.
+  func nextCharacter(offset: Int, data: String)
+  -> (offset: Int, char: Character?, whitespace: String) {
+    var whitespaceBuffer = ""
+
+    for i in offset..<data.count {
+      let index = data.index(data.startIndex, offsetBy: i)
+      let char = data[index]
+
+      if [" ", "\n"].contains(char) {
+        whitespaceBuffer += String(char)
+      }
+      else {
+        return (offset: i, char: char, whitespace: whitespaceBuffer)
+      }
+    }
+    return (offset: data.count - 1, char: nil, whitespace: whitespaceBuffer)
+  }
+
+  /// Given a string and a printable charater offset, calculate the line and column number.
+  ///
+  /// - Parameters:
+  ///   - offset: The printable character offset.
+  ///   - data: The input string for which we want the line and column numbers.
+  /// - Returns a tuple with the line and column numbers within `data`.
+  func calculatePosition(offset: Int, data: String) -> (line: Int, column: Int) {
+    var line = 1
+    var column = 0
+
+    for (index, char) in data.enumerated() {
+      if char == "\n" {
+        line += 1
+        column = 0
+      }
+      else {
+        column += 1
+      }
+      if index == offset { break }
+    }
+    return (line: line, column: column)
+  }
+
+  /// Emits the provided diagnostic message to the DiagnosticEngine. The message will correspond to
+  /// a specific location (line and column number) in the input Swift source file (`userText`).
+  ///
+  /// - Parameters:
+  ///   - message: The Diagnostic.Message object we wish to emit.
+  ///   - line: The line number location of the message
+  ///   - column: The column number location of the message
+  ///   - utf8Offset: The utf8 offset location of the message
+  ///   - actions: Used for attaching notes, highlights, etc.
+  func diagnose(
+    _ message: Diagnostic.Message,
+    line: Int,
+    column: Int,
+    utf8Offset: Int,
+    actions: ((inout Diagnostic.Builder) -> Void)? = nil
+  ) {
+    let loc = SourceLocation(
+      file: context.fileURL.path,
+      position: AbsolutePosition(line: line, column: column, utf8Offset: utf8Offset)
+    )
+    context.diagnosticEngine?.diagnose(
+      message,
+      location: loc,
+      actions: actions
+    )
+  }
+}
+
+extension Diagnostic.Message {
+  static let trailingWhitespaceError = Diagnostic.Message(
+    .warning, "[TrailingWhitespace]: remove trailing whitespace.")
+  static func indentationError(_ spaces: Int) -> Diagnostic.Message {
+    return .init(.warning, "[Indentation]: indentation should be \(spaces) spaces.")
+  }
+  static func spacingError(_ spaces: Int) -> Diagnostic.Message {
+    return .init(.warning, "[Spacing]: should be \(spaces) spaces.")
+  }
+  static let removeLineError = Diagnostic.Message(.warning, "[RemoveLine]: remove line break.")
+  static func addLinesError(_ lines: Int) -> Diagnostic.Message {
+    return .init(.warning, "[AddLines]: add \(lines) line breaks.")
+  }
+}

--- a/Tests/SwiftFormatWhitespaceLinterTests/WhitespaceLintTests.swift
+++ b/Tests/SwiftFormatWhitespaceLinterTests/WhitespaceLintTests.swift
@@ -1,0 +1,132 @@
+@testable import SwiftFormatWhitespaceLinter
+
+public class WhitespaceLintTests: WhitespaceTestCase {
+  public func testSpacing() {
+    let input =
+      """
+      let a : Int = 123
+      let b =456
+
+      """
+
+    let expected =
+      """
+      let a: Int = 123
+      let b = 456
+
+      """
+
+    performWhitespaceLint(input: input, expected: expected)
+    XCTAssertDiagnosed(.spacingError(0), line: 1, column: 6)
+    XCTAssertDiagnosed(.spacingError(1), line: 2, column: 8)
+  }
+
+  public func testIndentation() {
+    let input =
+      """
+        let a = 123
+      let b = 456
+       let c = "abc"
+
+      """
+
+    let expected =
+      """
+      let a = 123
+        let b = 456
+      let c = "abc"
+
+      """
+
+    performWhitespaceLint(input: input, expected: expected)
+    XCTAssertDiagnosed(.indentationError(0), line: 1, column: 1)
+    XCTAssertDiagnosed(.indentationError(2), line: 2, column: 1)
+    XCTAssertDiagnosed(.indentationError(0), line: 3, column: 1)
+  }
+
+  public func testTrailingWhitespace() {
+    let input =
+      """
+      let a = 123\u{20}\u{20}
+      let b = "abc"\u{20}
+      let c = "def"
+      \u{20}\u{20}
+      let d = 456\u{20}\u{20}\u{20}
+
+      """
+
+    let expected =
+      """
+      let a = 123
+      let b = "abc"
+      let c = "def"
+
+      let d = 456
+
+      """
+
+    performWhitespaceLint(input: input, expected: expected)
+    XCTAssertDiagnosed(.trailingWhitespaceError, line: 1, column: 12)
+    XCTAssertDiagnosed(.trailingWhitespaceError, line: 2, column: 14)
+    XCTAssertDiagnosed(.trailingWhitespaceError, line: 4, column: 1)
+    XCTAssertDiagnosed(.trailingWhitespaceError, line: 5, column: 12)
+  }
+
+  public func testAddLines() {
+    let input =
+      """
+      let a = 123
+      let b = "abc"
+      func myfun() { return }
+
+      """
+
+    let expected =
+      """
+      let a = 123
+
+      let b = "abc"
+      func myfun() {
+        return
+      }
+
+      """
+
+    performWhitespaceLint(input: input, expected: expected)
+    XCTAssertDiagnosed(.addLinesError(1), line: 2, column: 0)
+    XCTAssertDiagnosed(.addLinesError(1), line: 3, column: 15)
+    XCTAssertDiagnosed(.addLinesError(1), line: 3, column: 22)
+  }
+
+  public func testRemoveLines() {
+    let input =
+      """
+      let a = 123
+
+      let b = "abc"
+
+
+      let c = 456
+      func myFun() {
+        return someValue
+      }
+
+      """
+
+    let expected =
+      """
+      let a = 123
+      let b = "abc"
+      let c = 456
+      func myFun() { return someValue }
+
+      """
+
+    performWhitespaceLint(input: input, expected: expected)
+    XCTAssertDiagnosed(.removeLineError, line: 2, column: 0)
+    XCTAssertDiagnosed(.removeLineError, line: 4, column: 0)
+    XCTAssertDiagnosed(.removeLineError, line: 5, column: 0)
+    XCTAssertDiagnosed(.removeLineError, line: 8, column: 0)
+    XCTAssertDiagnosed(.removeLineError, line: 9, column: 0)
+  }
+}

--- a/Tests/SwiftFormatWhitespaceLinterTests/WhitespaceTestCase.swift
+++ b/Tests/SwiftFormatWhitespaceLinterTests/WhitespaceTestCase.swift
@@ -1,0 +1,93 @@
+import SwiftFormatConfiguration
+import SwiftFormatCore
+import SwiftSyntax
+import XCTest
+
+@testable import SwiftFormatWhitespaceLinter
+
+/// This test class allows us to check for specific diagnostics emitted by the DiagnosticEngine. It
+/// is similar to SwiftFormatRulesTests/DiagnosingTestCase, except that this class also tests for
+/// the specific line and column numbers of the diagnostic location.
+public class WhitespaceTestCase: XCTestCase {
+
+  /// The context in which to run the test.
+  public private(set) var context: Context?
+
+  /// Keeps track of the linter errors queued up in the DiagnosticEngine.
+  private var consumer = DiagnosticTrackingConsumer()
+
+  /// Used to indicate that a test should fail if we don't have test assertions for all diagnotics
+  /// emmitted.
+  private var shouldCheckForUnassertedDiagnostics = false
+
+  private class DiagnosticTrackingConsumer: DiagnosticConsumer {
+    var registeredDiagnostics = [(String, line: Int?, column: Int?)]()
+    func handle(_ diagnostic: Diagnostic) {
+      let loc = diagnostic.location
+      registeredDiagnostics.append((diagnostic.message.text, line: loc?.line, column: loc?.column))
+    }
+    func finalize() {}
+  }
+
+  public override func setUp() {
+    context = Context(
+      configuration: Configuration(),
+      diagnosticEngine: DiagnosticEngine(),
+      fileURL: URL(fileURLWithPath: "/tmp/test.swift")
+    )
+    consumer = DiagnosticTrackingConsumer()
+    context?.diagnosticEngine?.addConsumer(consumer)
+  }
+
+  public override func tearDown() {
+    guard shouldCheckForUnassertedDiagnostics else { return }
+
+    for diag in consumer.registeredDiagnostics {
+      XCTFail("unexpected diagnostic '\(diag)' emitted")
+    }
+  }
+
+  /// Perform whitespace linting by comparing the input text from the user with the expected
+  /// formatted text.
+  ///
+  /// - Parameters:
+  ///  - input: The user's input text.
+  ///  - expected: The formatted text.
+  func performWhitespaceLint(
+    input: String,
+    expected: String
+  ) {
+    shouldCheckForUnassertedDiagnostics = true
+    if let ctx = self.context {
+      let ws = WhitespaceLinter(user: input, formatted: expected, context: ctx)
+      ws.lint()
+    }
+  }
+
+  /// Asserts that a specific diagnostic message was emitted.
+  ///
+  /// - Parameters:
+  ///   - message: The diagnostic message to check for.
+  ///   - line: The line number of the diagnotic message within the ueser's input text.
+  ///   - column: The column number of the diagnostic message within the user's input text.
+  ///   - file: The file the test resides in (defaults to the current caller's file).
+  ///   - sourceLine: The line the test resides in (defaults to the current caller's file).
+  func XCTAssertDiagnosed(
+    _ message: Diagnostic.Message,
+    line: Int? = nil,
+    column: Int? = nil,
+    file: StaticString = #file,
+    sourceLine: UInt = #line
+  ) {
+    let maybeIdx = consumer.registeredDiagnostics.index {
+      $0 == (message.text, line: line, column: column)
+    }
+
+    guard let idx = maybeIdx else {
+      XCTFail("diagnostic '\(message.text)' not raised", file: file, line: sourceLine)
+      return
+    }
+
+    consumer.registeredDiagnostics.remove(at: idx)
+  }
+}


### PR DESCRIPTION
Currently, the way we handle linting for whitespace is to use Stage 1 rules, implemented in `Sources/SwiftFormatRules`. The pretty-printer now handles all formatting of whitespace in a Swift file. It does not have linting capability, so we have to maintain separate Stage 1 rules for the purposes of linting whitespace.

The changes introduced in this PR use the output of the pretty-printer and compares it to the user's input text to check for whitespace lint errors. This means that any changes we make to the pretty-printer's handling of whitespace will automatically result in the appropriate linter errors without the need to maintain separate Stage 1.

Note: In format mode, the pretty-printer receives the head AST node after the Stage 1 rules have had a chance to transform it. In this situation, we feed an unmodified AST into the pretty-printer. The user's text and the pretty-printer's formatted text must be identical except for whitespace characters.