### PR TITLE
More gracefully check that an input file exists

### DIFF
--- a/Sources/SwiftFormat/SwiftFormatError.swift
+++ b/Sources/SwiftFormat/SwiftFormatError.swift
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public enum SwiftFormatError: Error {
+  case fileNotFound
+}

--- a/Sources/SwiftFormat/SwiftFormatter.swift
+++ b/Sources/SwiftFormat/SwiftFormatter.swift
@@ -50,6 +50,9 @@ public final class SwiftFormatter {
   public func format<Output: TextOutputStream>(
     contentsOf url: URL, to outputStream: inout Output
   ) throws {
+    guard FileManager.default.isReadableFile(atPath: url.path) else {
+      throw SwiftFormatError.fileNotFound
+    }
     let sourceFile = try SyntaxTreeParser.parse(url)
     try format(syntax: sourceFile, assumingFileURL: url, to: &outputStream)
   }

--- a/Sources/SwiftFormat/SwiftLinter.swift
+++ b/Sources/SwiftFormat/SwiftLinter.swift
@@ -46,6 +46,9 @@ public final class SwiftLinter {
   /// - Parameters url: The URL of the file containing the code to format.
   /// - Throws: If an unrecoverable error occurs when formatting the code.
   public func lint(contentsOf url: URL) throws {
+    guard FileManager.default.isReadableFile(atPath: url.path) else {
+      throw SwiftFormatError.fileNotFound
+    }
     let sourceFile = try SyntaxTreeParser.parse(url)
     try lint(syntax: sourceFile, assumingFileURL: url)
   }


### PR DESCRIPTION
Explicitly handle the case where an input file doesn't exist, and emit an appropriate error.