### PR TITLE
Check the configuration to see if rules should be skipped

### DIFF
--- a/Sources/SwiftFormatConfiguration/Configuration.swift
+++ b/Sources/SwiftFormatConfiguration/Configuration.swift
@@ -28,12 +28,20 @@ public class Configuration: Codable {
     case respectsExistingLineBreaks
     case blankLineBetweenMembers
     case surroundSymbolsWithBackticks
+    case suppressFormatRules
+    case suppressLintRules
   }
 
   /// The version of this configuration.
   private let version: Int
 
   /// MARK: Common configuration
+
+  /// List of rule names to skip when running in format mode.
+  public var suppressFormatRules: [String] = []
+
+  /// List of rule names to skip when running in lint mode.
+  public var suppressLintRules: [String] = []
 
   /// The maximum number of consecutive blank lines that may appear in a file.
   public var maximumBlankLines = 1
@@ -101,6 +109,8 @@ public class Configuration: Codable {
     self.blankLineBetweenMembers = try container.decodeIfPresent(
       BlankLineBetweenMembersConfiguration.self, forKey: .blankLineBetweenMembers)
       ?? BlankLineBetweenMembersConfiguration()
+    self.suppressFormatRules = try container.decodeIfPresent([String].self, forKey: .suppressFormatRules) ?? []
+    self.suppressLintRules = try container.decodeIfPresent([String].self, forKey: .suppressLintRules) ?? []
   }
 
   public func encode(to encoder: Encoder) throws {
@@ -113,6 +123,8 @@ public class Configuration: Codable {
     try container.encode(indentation, forKey: .indentation)
     try container.encode(respectsExistingLineBreaks, forKey: .respectsExistingLineBreaks)
     try container.encode(blankLineBetweenMembers, forKey: .blankLineBetweenMembers)
+    try container.encode(suppressFormatRules, forKey: .suppressFormatRules)
+    try container.encode(suppressLintRules, forKey: .suppressLintRules)
   }
 }
 

--- a/Sources/SwiftFormatCore/FormatPipeline.swift
+++ b/Sources/SwiftFormatCore/FormatPipeline.swift
@@ -49,7 +49,7 @@ public final class FormatPipeline: SyntaxRewriter, Pipeline {
   public func addFormatter(_ formatType: SyntaxFormatRule.Type, for syntaxTypes: Syntax.Type...) {
     for type in syntaxTypes {
       let formatter = formatType.init(context: context)
-
+      if context.configuration.suppressFormatRules.contains(formatter.ruleName) { continue }
       // TODO(b/77533378): Respect priority of inserted Formatting passes. Should this be sorted on
       //                   insertion based on the priority of the pass type?
       passMap[SyntaxType(type: type), default: []].append(formatter.visit)

--- a/Sources/SwiftFormatCore/LintPipeline.swift
+++ b/Sources/SwiftFormatCore/LintPipeline.swift
@@ -51,6 +51,7 @@ public final class LintPipeline: SyntaxVisitor, Pipeline {
   public func addLinter(_ lintRule: SyntaxLintRule.Type, for syntaxTypes: Syntax.Type...) {
     for type in syntaxTypes {
       let rule = lintRule.init(context: context)
+      if context.configuration.suppressLintRules.contains(rule.ruleName) { continue }
       passMap[SyntaxType(type: type), default: []].append(.linter(rule))
     }
   }
@@ -64,6 +65,7 @@ public final class LintPipeline: SyntaxVisitor, Pipeline {
   public func addFormatter(_ formatRule: SyntaxFormatRule.Type, for syntaxTypes: Syntax.Type...) {
     for type in syntaxTypes {
       let rule = formatRule.init(context: context)
+      if context.configuration.suppressLintRules.contains(rule.ruleName) { continue }
       passMap[SyntaxType(type: type), default: []].append(.formatter(rule))
     }
   }


### PR DESCRIPTION
This PR allows you to suppress rules from a configuration file. For example:
```json
{
  "blankLineBetweenMembers" : {
    "ignoreSingleLineProperties" : true
  },
  "indentation" : {
    "spaces" : 2
  },
  "lineLength" : 100,
  "maximumBlankLines" : 1,
  "respectsExistingLineBreaks" : true,
  "suppressFormatRules" : [
    "DoNotUseSemicolons"
  ],
  "suppressLintRules": [
    "DoNotUseSemicolons"
  ],
  "tabWidth" : 8,
  "version" : 1
}
```