### PR TITLE
Make the line break before control flow keywords configurable.

### DIFF
--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -46,6 +46,12 @@ top-level keys and values:
         property declarations are allowed to appear consecutively without a
         blank line separating them.
 
+*   `lineBreakBeforeControlFlowKeywords` _(boolean)_: Determines the
+    line-breaking behavior for control flow keywords that follow a closing
+    brace, like `else` and `catch`. If true, a line break will be added before
+    the keyword, forcing it onto its own line. If false (the default), the
+    keyword will be placed after the closing brace (separated by a space).
+
 > TODO: Add support for enabling/disabling specific syntax transformations in
 > the pipeline.
 
@@ -64,7 +70,8 @@ An example `.swift-format` configuration file is shown below.
     "respectsExistingLineBreaks": true,
     "blankLineBetweenMembers": {
         "ignoreSingleLineProperties": true
-    }
+    },
+    "lineBreakBeforeControlFlowKeywords": true
 }
 ```
 

--- a/Sources/SwiftFormatConfiguration/Configuration.swift
+++ b/Sources/SwiftFormatConfiguration/Configuration.swift
@@ -27,7 +27,7 @@ public class Configuration: Codable {
     case indentation
     case respectsExistingLineBreaks
     case blankLineBetweenMembers
-    case surroundSymbolsWithBackticks
+    case lineBreakBeforeControlFlowKeywords
     case rules
   }
 
@@ -70,6 +70,14 @@ public class Configuration: Codable {
   /// Rules for limiting blank lines between members.
   public var blankLineBetweenMembers = BlankLineBetweenMembersConfiguration()
 
+  /// Determines the line-breaking behavior for control flow keywords that follow a closing brace,
+  /// like `else` and `catch`.
+  ///
+  /// If true, a line break will be added before the keyword, forcing it onto its own line. If
+  /// false (the default), the keyword will be placed after the closing brace (separated by a
+  /// space).
+  public var lineBreakBeforeControlFlowKeywords = false
+
   /// Constructs a Configuration with all default values.
   public init() {
     self.version = highestSupportedConfigurationVersion
@@ -107,6 +115,9 @@ public class Configuration: Codable {
     self.blankLineBetweenMembers = try container.decodeIfPresent(
       BlankLineBetweenMembersConfiguration.self, forKey: .blankLineBetweenMembers)
       ?? BlankLineBetweenMembersConfiguration()
+    self.lineBreakBeforeControlFlowKeywords
+      = try container.decodeIfPresent(Bool.self, forKey: .lineBreakBeforeControlFlowKeywords)
+      ?? true
     self.rules = try container.decodeIfPresent([String: Bool].self, forKey: .rules) ?? [:]
   }
 
@@ -120,6 +131,8 @@ public class Configuration: Codable {
     try container.encode(indentation, forKey: .indentation)
     try container.encode(respectsExistingLineBreaks, forKey: .respectsExistingLineBreaks)
     try container.encode(blankLineBetweenMembers, forKey: .blankLineBetweenMembers)
+    try container.encode(
+      lineBreakBeforeControlFlowKeywords, forKey: .lineBreakBeforeControlFlowKeywords)
     try container.encode(rules, forKey: .rules)
   }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/AvailabilityConditionTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/AvailabilityConditionTests.swift
@@ -80,8 +80,7 @@ public class AvailabilityConditionTests: PrettyPrintTestCase {
 
       if #available(OSX 10.12, *) {
         // Do stuff
-      }
-      else {
+      } else {
         let a = 123
         let b = "abc"
       }
@@ -89,8 +88,7 @@ public class AvailabilityConditionTests: PrettyPrintTestCase {
       #if canImport(os)
         if #available(OSX 10.12, *) {
           // Do stuff
-        }
-        else {
+        } else {
           let a = 123
           let b = "abc"
         }
@@ -101,8 +99,7 @@ public class AvailabilityConditionTests: PrettyPrintTestCase {
         if #available(OSX 10.12, *) {
 
           let a = 123
-        }
-        else {
+        } else {
           // do stuff
         }
       }

--- a/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/IfStmtTests.swift
@@ -1,3 +1,5 @@
+import SwiftFormatConfiguration
+
 public class IfStmtTests: PrettyPrintTestCase {
   public func testIfStatement() {
     let input =
@@ -59,7 +61,51 @@ public class IfStmtTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 20)
   }
 
-  public func testIfElseStatement() {
+  public func testIfElseStatement_noBreakBeforeElse() {
+    let input =
+      """
+      if var1 < var2 {
+        let a = 23
+      }
+      else if d < e {
+        var b = 123
+      }
+      else {
+        var c = 456
+      }
+
+      if var1 < var2 {
+        let a = 23
+      }
+      else if var3 < var4 {
+        var b = 123
+        var c = 456
+      }
+      """
+
+    let expected =
+      """
+      if var1 < var2 {
+        let a = 23
+      } else if d < e {
+        var b = 123
+      } else {
+        var c = 456
+      }
+
+      if var1 < var2 {
+        let a = 23
+      } else if var3 < var4 {
+        var b = 123
+        var c = 456
+      }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 23)
+  }
+
+  public func testIfElseStatement_breakBeforeElse() {
     let input =
       """
       if var1 < var2 {
@@ -101,7 +147,9 @@ public class IfStmtTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20)
+    let config = Configuration()
+    config.lineBreakBeforeControlFlowKeywords = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 20, configuration: config)
   }
 
   public func testMatchingPatternConditions() {

--- a/Tests/SwiftFormatPrettyPrintTests/PrettyPrintTestCase.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/PrettyPrintTestCase.swift
@@ -11,10 +11,10 @@ public class PrettyPrintTestCase: XCTestCase {
     input: String,
     expected: String,
     linelength: Int,
+    configuration: Configuration = Configuration(),
     file: StaticString = #file,
     line: UInt = #line
   ) {
-    let configuration = Configuration()
     configuration.lineLength = linelength
 
     let context = Context(

--- a/Tests/SwiftFormatPrettyPrintTests/RepeatStmtTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/RepeatStmtTests.swift
@@ -1,5 +1,51 @@
+import SwiftFormatConfiguration
+
 public class RepeatStmtTests: PrettyPrintTestCase {
-  public func testBasicRepeatTests() {
+
+  public func testBasicRepeatTests_noBreakBeforeWhile() {
+    let input =
+      """
+      repeat {}
+      while x
+      repeat { f() }
+      while x
+      repeat { foo() }
+      while longcondition
+      repeat {
+        let a = 123
+        var b = "abc"
+      }
+      while condition
+      repeat {
+        let a = 123
+        var b = "abc"
+      }
+      while condition && condition2
+      """
+
+    let expected =
+      """
+      repeat {} while x
+      repeat { f() } while x
+      repeat {
+        foo()
+      } while longcondition
+      repeat {
+        let a = 123
+        var b = "abc"
+      } while condition
+      repeat {
+        let a = 123
+        var b = "abc"
+      } while condition
+        && condition2
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
+  }
+
+  public func testBasicRepeatTests_breakBeforeWhile() {
     let input =
       """
       repeat {} while x
@@ -37,7 +83,9 @@ public class RepeatStmtTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
+    let config = Configuration()
+    config.lineBreakBeforeControlFlowKeywords = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 25, configuration: config)
   }
 
   public func testNestedRepeat() {
@@ -48,8 +96,7 @@ public class RepeatStmtTests: PrettyPrintTestCase {
         repeat {
           bar()
           baz()
-        }
-        while condition
+        } while condition
       }
       """
     assertPrettyPrintEqual(input: input, expected: input + "\n", linelength: 45)

--- a/Tests/SwiftFormatPrettyPrintTests/TryCatchTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/TryCatchTests.swift
@@ -1,3 +1,5 @@
+import SwiftFormatConfiguration
+
 public class TryCatchTests: PrettyPrintTestCase {
   public func testBasicTries() {
     let input =
@@ -18,7 +20,55 @@ public class TryCatchTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
   }
 
-  public func testDoTryCatch() {
+  public func testDoTryCatch_noBreakBeforeCatch() {
+    let input =
+      """
+      do { try thisFuncMightFail() } catch error1 { print("Nope") }
+      do { try thisFuncMightFail() } catch error1 { print("Nope") } catch error2 { print("Nope") }
+      do { try thisFuncMightFail() } catch error1 { print("Nope") } catch error2(let someVar) { print("Nope") }
+      do { try thisFuncMightFail() } catch error1 { print("Nope") }
+      catch error2(let someVar) {
+        print(someVar)
+        print("Don't do it!")
+      }
+      do { try thisFuncMightFail() } catch is ABadError{ print("Nope") }
+      """
+
+    let expected =
+      """
+      do {
+        try thisFuncMightFail()
+      } catch error1 { print("Nope") }
+      do {
+        try thisFuncMightFail()
+      } catch error1 {
+        print("Nope")
+      } catch error2 { print("Nope") }
+      do {
+        try thisFuncMightFail()
+      } catch error1 {
+        print("Nope")
+      } catch error2(let someVar) {
+        print("Nope")
+      }
+      do {
+        try thisFuncMightFail()
+      } catch error1 {
+        print("Nope")
+      } catch error2(let someVar) {
+        print(someVar)
+        print("Don't do it!")
+      }
+      do {
+        try thisFuncMightFail()
+      } catch is ABadError { print("Nope") }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+  }
+
+  public func testDoTryCatch_breakBeforeCatch() {
     let input =
       """
       do { try thisFuncMightFail() } catch error1 { print("Nope") }
@@ -55,10 +105,37 @@ public class TryCatchTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+    let config = Configuration()
+    config.lineBreakBeforeControlFlowKeywords = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: config)
   }
 
-  public func testCatchWhere() {
+  public func testCatchWhere_noBreakBeforeCatch() {
+    let input =
+      """
+      do { try thisFuncMightFail() } catch error1 where error1 is ErrorType { print("Nope") }
+      do { try thisFuncMightFail() } catch error1 where error1 is LongerErrorType { print("Nope") }
+      """
+
+    let expected =
+      """
+      do {
+        try thisFuncMightFail()
+      } catch error1 where error1 is ErrorType {
+        print("Nope")
+      }
+      do {
+        try thisFuncMightFail()
+      } catch error1
+        where error1 is LongerErrorType
+      { print("Nope") }
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 42)
+  }
+
+  public func testCatchWhere_breakBeforeCatch() {
     let input =
       """
       do { try thisFuncMightFail() } catch error1 where error1 is ErrorType { print("Nope") }
@@ -79,7 +156,9 @@ public class TryCatchTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 42)
+    let config = Configuration()
+    config.lineBreakBeforeControlFlowKeywords = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 42, configuration: config)
   }
 
   public func testNestedDo() {


### PR DESCRIPTION
This changes the default behavior (for now) to _not_ put a line break before `else`, `catch`, etc. We may revisit this decision later, but it's possible with a configuration setting now.