### PR TITLE
Make packing of argument lists configurable.

### DIFF
--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -52,6 +52,13 @@ top-level keys and values:
     the keyword, forcing it onto its own line. If false (the default), the
     keyword will be placed after the closing brace (separated by a space).
 
+*   `lineBreakBeforeEachArgument` _(boolean)_: Determines the line-breaking
+    behavior for generic arguments and function arguments when a declaration is
+    wrapped onto multiple lines. If true (the default), a line break will be
+    added before each argument, forcing the entire argument list to be laid out
+    vertically. If false, arguments will be laid out horizontally first, with
+    line breaks only being fired when the line length would be exceeded.
+
 > TODO: Add support for enabling/disabling specific syntax transformations in
 > the pipeline.
 
@@ -71,7 +78,8 @@ An example `.swift-format` configuration file is shown below.
     "blankLineBetweenMembers": {
         "ignoreSingleLineProperties": true
     },
-    "lineBreakBeforeControlFlowKeywords": true
+    "lineBreakBeforeControlFlowKeywords": true,
+    "lineBreakBeforeEachArgument": true
 }
 ```
 

--- a/Sources/SwiftFormatConfiguration/Configuration.swift
+++ b/Sources/SwiftFormatConfiguration/Configuration.swift
@@ -28,6 +28,7 @@ public class Configuration: Codable {
     case respectsExistingLineBreaks
     case blankLineBetweenMembers
     case lineBreakBeforeControlFlowKeywords
+    case lineBreakBeforeEachArgument
     case rules
   }
 
@@ -78,6 +79,14 @@ public class Configuration: Codable {
   /// space).
   public var lineBreakBeforeControlFlowKeywords = false
 
+  /// Determines the line-breaking behavior for generic arguments and function arguments when a
+  /// declaration is wrapped onto multiple lines.
+  ///
+  /// If true (the default), a line break will be added before each argument, forcing the entire
+  /// argument list to be laid out vertically. If false, arguments will be laid out horizontally
+  /// first, with line breaks only being fired when the line length would be exceeded.
+  public var lineBreakBeforeEachArgument = true
+
   /// Constructs a Configuration with all default values.
   public init() {
     self.version = highestSupportedConfigurationVersion
@@ -118,6 +127,8 @@ public class Configuration: Codable {
     self.lineBreakBeforeControlFlowKeywords
       = try container.decodeIfPresent(Bool.self, forKey: .lineBreakBeforeControlFlowKeywords)
       ?? true
+    self.lineBreakBeforeEachArgument
+      = try container.decodeIfPresent(Bool.self, forKey: .lineBreakBeforeEachArgument) ?? true
     self.rules = try container.decodeIfPresent([String: Bool].self, forKey: .rules) ?? [:]
   }
 
@@ -133,6 +144,7 @@ public class Configuration: Codable {
     try container.encode(blankLineBetweenMembers, forKey: .blankLineBetweenMembers)
     try container.encode(
       lineBreakBeforeControlFlowKeywords, forKey: .lineBreakBeforeControlFlowKeywords)
+    try container.encode(lineBreakBeforeEachArgument, forKey: .lineBreakBeforeEachArgument)
     try container.encode(rules, forKey: .rules)
   }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/ClassDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClassDeclTests.swift
@@ -1,4 +1,7 @@
+import SwiftFormatConfiguration
+
 public class ClassDeclTests: PrettyPrintTestCase {
+
   public func testBasicClassDeclarations() {
     let input =
       """
@@ -38,7 +41,51 @@ public class ClassDeclTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
   }
 
-  public func testGenericClassDeclarations() {
+  public func testGenericClassDeclarations_noPackArguments() {
+    let input =
+      """
+      class MyClass<T> {
+        let A: Int
+        let B: Bool
+      }
+      class MyClass<T, S> {
+        let A: Int
+        let B: Bool
+      }
+      class MyClass<One, Two, Three, Four> {
+        let A: Int
+        let B: Bool
+      }
+      """
+
+    let expected =
+      """
+      class MyClass<T> {
+        let A: Int
+        let B: Bool
+      }
+      class MyClass<T, S> {
+        let A: Int
+        let B: Bool
+      }
+      class MyClass<
+        One,
+        Two,
+        Three,
+        Four
+      > {
+        let A: Int
+        let B: Bool
+      }
+
+      """
+
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+  }
+
+  public func testGenericClassDeclarations_packArguments() {
     let input =
       """
       class MyClass<T> {
@@ -74,7 +121,9 @@ public class ClassDeclTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30, configuration: config)
   }
 
   public func testClassInheritence() {
@@ -262,7 +311,9 @@ public class ClassDeclTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }
 
   public func testEmptyClass() {

--- a/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/ClosureExprTests.swift
@@ -1,5 +1,73 @@
+import SwiftFormatConfiguration
+
 public class ClosureExprTests: PrettyPrintTestCase {
-  public func testBasicFunctionClosures() {
+
+  public func testBasicFunctionClosures_noPackArguments() {
+    let input =
+      """
+      funcCall(closure: <)
+      funcCall(closure: { 4 })
+      funcCall(closure: { $0 < $1 })
+      funcCall(closure: { s1, s2 in s1 < s2 })
+      funcCall(closure: { s1, s2 in return s1 < s2})
+      funcCall(closure: { s1, s2, s3, s4, s5, s6 in return s1})
+      funcCall(closure: { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 in return s1 })
+      funcCall(param1: 123, closure: { s1, s2, s3 in return s1 })
+      funcCall(closure: { (s1: String, s2: String) -> Bool in return s1 > s2 })
+      """
+
+    let expected =
+      """
+      funcCall(closure: <)
+      funcCall(closure: { 4 })
+      funcCall(closure: { $0 < $1 })
+      funcCall(closure: { s1, s2 in
+        s1 < s2
+      })
+      funcCall(closure: { s1, s2 in
+        return s1 < s2
+      })
+      funcCall(closure: {
+        s1,
+        s2,
+        s3,
+        s4,
+        s5,
+        s6 in
+        return s1
+      })
+      funcCall(closure: {
+        s1,
+        s2,
+        s3,
+        s4,
+        s5,
+        s6,
+        s7,
+        s8,
+        s9,
+        s10 in
+        return s1
+      })
+      funcCall(
+        param1: 123,
+        closure: { s1, s2, s3 in
+          return s1
+        }
+      )
+      funcCall(closure: {
+        (s1: String, s2: String) -> Bool in
+        return s1 > s2
+      })
+
+      """
+
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 42, configuration: config)
+  }
+
+  public func testBasicFunctionClosures_packArguments() {
     let input =
       """
       funcCall(closure: <)
@@ -45,7 +113,9 @@ public class ClosureExprTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 42)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 42, configuration: config)
   }
 
   public func testTrailingClosure() {
@@ -71,7 +141,9 @@ public class ClosureExprTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: config)
   }
 
   public func testClosuresWithIfs() {

--- a/Tests/SwiftFormatPrettyPrintTests/EnumDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/EnumDeclTests.swift
@@ -1,4 +1,7 @@
+import SwiftFormatConfiguration
+
 public class EnumDeclTests: PrettyPrintTestCase {
+
   public func testBasicEnumDeclarations() {
     let input =
       """
@@ -38,7 +41,51 @@ public class EnumDeclTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 23)
   }
 
-  public func testMixedEnumCaseStyles() {
+  public func testMixedEnumCaseStyles_noPackArguments() {
+    let input =
+      """
+      enum MyEnum {
+        case first
+        case second, third
+        case fourth(Int)
+        case fifth(a: Int, b: Bool)
+      }
+      enum MyEnum {
+        case first
+        case second, third, fourth, fifth
+        case sixth(Int)
+        case seventh(a: Int, b: Bool, c: Double)
+      }
+      """
+
+    let expected =
+      """
+      enum MyEnum {
+        case first
+        case second, third
+        case fourth(Int)
+        case fifth(a: Int, b: Bool)
+      }
+      enum MyEnum {
+        case first
+        case second, third, fourth,
+          fifth
+        case sixth(Int)
+        case seventh(
+          a: Int,
+          b: Bool,
+          c: Double
+        )
+      }
+
+      """
+
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30, configuration: config)
+  }
+
+  public func testMixedEnumCaseStyles_packArguments() {
     let input =
       """
       enum MyEnum {
@@ -75,7 +122,9 @@ public class EnumDeclTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30, configuration: config)
   }
 
   public func testIndirectEnum() {
@@ -151,7 +200,9 @@ public class EnumDeclTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30, configuration: config)
   }
 
   public func testEnumInheritence() {
@@ -339,7 +390,9 @@ public class EnumDeclTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }
 
   public func testEmptyEnum() {

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionCallTests.swift
@@ -1,5 +1,66 @@
+import SwiftFormatConfiguration
+
 public class FunctionCallTests: PrettyPrintTestCase {
-  public func testBasicFunctionCalls() {
+
+  public func testBasicFunctionCalls_noPackArguments() {
+    let input =
+      """
+      let a = myFunc()
+      let a = myFunc(var1: 123, var2: "abc")
+      let a = myFunc(var1: 123, var2: "abc", var3: Bool, var4: (1, 2, 3))
+      let a = myFunc(var1, var2, var3)
+      let a = myFunc(var1, var2, var3, var4, var5, var6)
+      let a = myFunc(var1, var2, var3, var4, var5, var6, var7, x)
+      let a = myFunc(var1: 123, var2: someFun(var1: "abc", var2: 123, var3: Bool, var4: 1.23))
+      """
+
+    let expected =
+      """
+      let a = myFunc()
+      let a = myFunc(var1: 123, var2: "abc")
+      let a = myFunc(
+        var1: 123,
+        var2: "abc",
+        var3: Bool,
+        var4: (1, 2, 3)
+      )
+      let a = myFunc(var1, var2, var3)
+      let a = myFunc(
+        var1,
+        var2,
+        var3,
+        var4,
+        var5,
+        var6
+      )
+      let a = myFunc(
+        var1,
+        var2,
+        var3,
+        var4,
+        var5,
+        var6,
+        var7,
+        x
+      )
+      let a = myFunc(
+        var1: 123,
+        var2: someFun(
+          var1: "abc",
+          var2: 123,
+          var3: Bool,
+          var4: 1.23
+        )
+      )
+
+      """
+
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45, configuration: config)
+  }
+
+  public func testBasicFunctionCalls_packArguments() {
     let input =
       """
       let a = myFunc()
@@ -32,7 +93,9 @@ public class FunctionCallTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45, configuration: config)
   }
 
   public func testDiscretionaryLineBreakBeforeClosingParenthesis() {
@@ -65,6 +128,8 @@ public class FunctionCallTests: PrettyPrintTestCase {
       )
 
       """
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45, configuration: config)
   }
 }

--- a/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/FunctionDeclTests.swift
@@ -1,5 +1,53 @@
+import SwiftFormatConfiguration
+
 public class FunctionDeclTests: PrettyPrintTestCase {
-  public func testBasicFunctionDeclarations() {
+
+  public func testBasicFunctionDeclarations_noPackArguments() {
+    let input =
+      """
+      func myFun(var1: Int, var2: Double) {
+        print("Hello World")
+        let a = 23
+      }
+      func reallyLongName(var1: Int, var2: Double, var3: Bool) {
+        print("Hello World")
+        let a = 23
+      }
+      func myFun() {
+        let a = 23
+      }
+      func myFun() { let a = "AAAA BBBB CCCC DDDD EEEE FFFF" }
+      """
+
+    let expected =
+      """
+      func myFun(var1: Int, var2: Double) {
+        print("Hello World")
+        let a = 23
+      }
+      func reallyLongName(
+        var1: Int,
+        var2: Double,
+        var3: Bool
+      ) {
+        print("Hello World")
+        let a = 23
+      }
+      func myFun() {
+        let a = 23
+      }
+      func myFun() {
+        let a = "AAAA BBBB CCCC DDDD EEEE FFFF"
+      }
+
+      """
+
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
+  }
+
+  public func testBasicFunctionDeclarations_packArguments() {
     let input =
       """
       func myFun(var1: Int, var2: Double) {
@@ -37,7 +85,9 @@ public class FunctionDeclTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }
 
   public func testFunctionDeclReturns() {
@@ -68,7 +118,9 @@ public class FunctionDeclTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }
 
   public func testFunctionDeclThrows() {
@@ -111,96 +163,149 @@ public class FunctionDeclTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }
 
-  public func testFunctionGenericParameters() {
+  public func testFunctionGenericParameters_noPackArguments() {
     let input =
-    """
-    func myFun<S, T>(var1: S, var2: T) {
-      let a = 123
-      print("Hello World")
-    }
+      """
+      func myFun<S, T>(var1: S, var2: T) {
+        let a = 123
+        print("Hello World")
+      }
 
-    func myFun<S: T & U>(var1: S) {
-      // do stuff
-    }
+      func myFun<S: T & U>(var1: S) {
+        // do stuff
+      }
 
-    func longerNameFun<ReallyLongTypeName: Conform, TypeName>(var1: ReallyLongTypeName, var2: TypeName) {
-      let a = 123
-      let b = 456
-    }
-    """
+      func longerNameFun<ReallyLongTypeName: Conform, TypeName>(var1: ReallyLongTypeName, var2: TypeName) {
+        let a = 123
+        let b = 456
+      }
+      """
 
     let expected =
-    """
-    func myFun<S, T>(var1: S, var2: T) {
-      let a = 123
-      print("Hello World")
-    }
+      """
+      func myFun<S, T>(var1: S, var2: T) {
+        let a = 123
+        print("Hello World")
+      }
 
-    func myFun<S: T & U>(var1: S) {
-      // do stuff
-    }
+      func myFun<S: T & U>(var1: S) {
+        // do stuff
+      }
 
-    func longerNameFun<
-      ReallyLongTypeName: Conform, TypeName
-    >(
-      var1: ReallyLongTypeName,
-      var2: TypeName
-    ) {
-      let a = 123
-      let b = 456
-    }
+      func longerNameFun<
+        ReallyLongTypeName: Conform,
+        TypeName
+      >(
+        var1: ReallyLongTypeName,
+        var2: TypeName
+      ) {
+        let a = 123
+        let b = 456
+      }
 
-    """
+      """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: config)
+  }
+
+  public func testFunctionGenericParameters_packArguments() {
+    let input =
+      """
+      func myFun<S, T>(var1: S, var2: T) {
+        let a = 123
+        print("Hello World")
+      }
+
+      func myFun<S: T & U>(var1: S) {
+        // do stuff
+      }
+
+      func longerNameFun<ReallyLongTypeName: Conform, TypeName>(var1: ReallyLongTypeName, var2: TypeName) {
+        let a = 123
+        let b = 456
+      }
+      """
+
+    let expected =
+      """
+      func myFun<S, T>(var1: S, var2: T) {
+        let a = 123
+        print("Hello World")
+      }
+
+      func myFun<S: T & U>(var1: S) {
+        // do stuff
+      }
+
+      func longerNameFun<
+        ReallyLongTypeName: Conform, TypeName
+      >(
+        var1: ReallyLongTypeName,
+        var2: TypeName
+      ) {
+        let a = 123
+        let b = 456
+      }
+
+      """
+
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: config)
   }
 
   public func testFunctionWhereClause() {
     let input =
-    """
-    public func index<Elements: Collection, Element>(
-      of element: Element, in collection: Elements
-    ) -> Elements.Index? where Elements.Element == Element {
-      let a = 123
-      let b = "abc"
-    }
+      """
+      public func index<Elements: Collection, Element>(
+        of element: Element, in collection: Elements
+      ) -> Elements.Index? where Elements.Element == Element {
+        let a = 123
+        let b = "abc"
+      }
 
-    public func index<Elements: Collection, Element>(
-      of element: Element,
-      in collection: Elements
-    ) -> Elements.Index? where Elements.Element == Element, Element: Equatable {
-      let a = 123
-      let b = "abc"
-    }
-    """
+      public func index<Elements: Collection, Element>(
+        of element: Element,
+        in collection: Elements
+      ) -> Elements.Index? where Elements.Element == Element, Element: Equatable {
+        let a = 123
+        let b = "abc"
+      }
+      """
 
     let expected =
-    """
-    public func index<Elements: Collection, Element>(
-      of element: Element, in collection: Elements
-    ) -> Elements.Index?
-    where Elements.Element == Element {
-      let a = 123
-      let b = "abc"
-    }
+      """
+      public func index<Elements: Collection, Element>(
+        of element: Element, in collection: Elements
+      ) -> Elements.Index?
+      where Elements.Element == Element {
+        let a = 123
+        let b = "abc"
+      }
 
-    public func index<Elements: Collection, Element>(
-      of element: Element,
-      in collection: Elements
-    ) -> Elements.Index?
-    where Elements.Element == Element,
-      Element: Equatable
-    {
-      let a = 123
-      let b = "abc"
-    }
+      public func index<Elements: Collection, Element>(
+        of element: Element,
+        in collection: Elements
+      ) -> Elements.Index?
+      where Elements.Element == Element,
+        Element: Equatable
+      {
+        let a = 123
+        let b = "abc"
+      }
 
-    """
+      """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }
 
   public func testFunctionWithDefer() {
@@ -550,7 +655,10 @@ public class FunctionDeclTests: PrettyPrintTestCase {
       }
 
       """
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 35)
+
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 35, configuration: config)
   }
 
   public func testRemovesLineBreakBeforeOpenBraceUnlessAbsolutelyNecessary() {

--- a/Tests/SwiftFormatPrettyPrintTests/InitializerDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/InitializerDeclTests.swift
@@ -1,5 +1,53 @@
+import SwiftFormatConfiguration
+
 public class InitializerDeclTests: PrettyPrintTestCase {
-  public func testBasicInitializerDeclarations() {
+
+  public func testBasicInitializerDeclarations_noPackArguments() {
+    let input =
+      """
+      struct Struct {
+        init(var1: Int, var2: Double) {
+            print("Hello World")
+            let a = 23
+        }
+        init(reallyLongLabelVar1: Int, var2: Double, var3: Bool) {
+            print("Hello World")
+            let a = 23
+        }
+        init() { let a = 23 }
+        init() { let a = "AAAA BBBB CCCC DDDD EEEE FFFF" }
+      }
+      """
+
+    let expected =
+      """
+      struct Struct {
+        init(var1: Int, var2: Double) {
+          print("Hello World")
+          let a = 23
+        }
+        init(
+          reallyLongLabelVar1: Int,
+          var2: Double,
+          var3: Bool
+        ) {
+          print("Hello World")
+          let a = 23
+        }
+        init() { let a = 23 }
+        init() {
+          let a = "AAAA BBBB CCCC DDDD EEEE FFFF"
+        }
+      }
+
+      """
+
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
+  }
+
+  public func testBasicInitializerDeclarations_packArguments() {
     let input =
       """
       struct Struct {
@@ -38,7 +86,9 @@ public class InitializerDeclTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }
 
   public func testInitializerOptionality() {
@@ -80,7 +130,9 @@ public class InitializerDeclTests: PrettyPrintTestCase {
 
       """
     
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }
 
   public func testInitializerDeclThrows() {
@@ -112,7 +164,9 @@ public class InitializerDeclTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }
 
   public func testInitializerGenericParameters() {
@@ -191,7 +245,9 @@ public class InitializerDeclTests: PrettyPrintTestCase {
 
     """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }
 
   public func testInitializerAttributes() {
@@ -238,35 +294,37 @@ public class InitializerDeclTests: PrettyPrintTestCase {
 
   public func testInitializerFullWrap() {
     let input =
-    """
-    struct Struct {
-      @objc @inlinable public init<Elements: Collection, Element>(element: Element, in collection: Elements) where Elements.Element == Element, Element: Equatable {
-        let a = 123
-        let b = "abc"
+      """
+      struct Struct {
+        @objc @inlinable public init<Elements: Collection, Element>(element: Element, in collection: Elements) where Elements.Element == Element, Element: Equatable {
+          let a = 123
+          let b = "abc"
+        }
       }
-    }
-    """
+      """
 
     let expected =
-    """
-    struct Struct {
-      @objc @inlinable public init<
-        Elements: Collection, Element
-      >(
-        element: Element,
-        in collection: Elements
-      )
-      where Elements.Element == Element,
-        Element: Equatable
-      {
-        let a = 123
-        let b = "abc"
+      """
+      struct Struct {
+        @objc @inlinable public init<
+          Elements: Collection, Element
+        >(
+          element: Element,
+          in collection: Elements
+        )
+        where Elements.Element == Element,
+          Element: Equatable
+        {
+          let a = 123
+          let b = "abc"
+        }
       }
-    }
 
-    """
+      """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: config)
   }
 
   public func testEmptyInitializer() {

--- a/Tests/SwiftFormatPrettyPrintTests/StructDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/StructDeclTests.swift
@@ -1,4 +1,7 @@
+import SwiftFormatConfiguration
+
 public class StructDeclTests: PrettyPrintTestCase {
+
   public func testBasicStructDeclarations() {
     let input =
       """
@@ -38,7 +41,51 @@ public class StructDeclTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 25)
   }
 
-  public func testGenericStructDeclarations() {
+  public func testGenericStructDeclarations_noPackArguments() {
+    let input =
+      """
+      struct MyStruct<T> {
+        let A: Int
+        let B: Bool
+      }
+      struct MyStruct<T, S> {
+        let A: Int
+        let B: Bool
+      }
+      struct MyStruct<One, Two, Three, Four> {
+        let A: Int
+        let B: Bool
+      }
+      """
+
+    let expected =
+      """
+      struct MyStruct<T> {
+        let A: Int
+        let B: Bool
+      }
+      struct MyStruct<T, S> {
+        let A: Int
+        let B: Bool
+      }
+      struct MyStruct<
+        One,
+        Two,
+        Three,
+        Four
+      > {
+        let A: Int
+        let B: Bool
+      }
+
+      """
+
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30, configuration: config)
+  }
+
+  public func testGenericStructDeclarations_packArguments() {
     let input =
       """
       struct MyStruct<T> {
@@ -74,7 +121,9 @@ public class StructDeclTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 30, configuration: config)
   }
 
   public func testStructInheritence() {
@@ -262,7 +311,9 @@ public class StructDeclTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }
 
   public func testEmptyStruct() {

--- a/Tests/SwiftFormatPrettyPrintTests/SubscriptDeclTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SubscriptDeclTests.swift
@@ -1,4 +1,7 @@
+import SwiftFormatConfiguration
+
 public class SubscriptDeclTests: PrettyPrintTestCase {
+
   public func testBasicSubscriptDeclarations() {
     let input =
       """
@@ -36,7 +39,52 @@ public class SubscriptDeclTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
   }
 
-  public func testSubscriptGenerics() {
+  public func testSubscriptGenerics_noPackArguments() {
+    let input =
+      """
+      struct MyStruct {
+        subscript<T>(index: T) -> Double {
+          return 1.23
+        }
+        subscript<S, T>(row: S, col: T) -> Double {
+          return self.values[row][col]
+        }
+        subscript<LongTypeName1, LongTypeName2, LongTypeName3>(var1: LongTypeName1, var2: LongTypeName2, var3: LongTypeName3) -> Int {
+          return self.values[var1][var2][var3]
+        }
+      }
+      """
+
+    let expected =
+      """
+      struct MyStruct {
+        subscript<T>(index: T) -> Double {
+          return 1.23
+        }
+        subscript<S, T>(row: S, col: T) -> Double {
+          return self.values[row][col]
+        }
+        subscript<
+          LongTypeName1,
+          LongTypeName2,
+          LongTypeName3
+        >(
+          var1: LongTypeName1,
+          var2: LongTypeName2,
+          var3: LongTypeName3
+        ) -> Int {
+          return self.values[var1][var2][var3]
+        }
+      }
+
+      """
+
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
+  }
+
+  public func testSubscriptGenerics_packArguments() {
     let input =
       """
       struct MyStruct {
@@ -73,7 +121,9 @@ public class SubscriptDeclTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }
 
   public func testSubscriptGenericWhere() {
@@ -109,7 +159,9 @@ public class SubscriptDeclTests: PrettyPrintTestCase {
 
       """
 
-    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50)
+    let config = Configuration()
+    config.lineBreakBeforeEachArgument = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 50, configuration: config)
   }
 
   public func testSubscriptAttributes() {

--- a/Tests/SwiftFormatPrettyPrintTests/SubscriptExprTests.swift
+++ b/Tests/SwiftFormatPrettyPrintTests/SubscriptExprTests.swift
@@ -52,7 +52,8 @@ public class SubscriptExprTests: PrettyPrintTestCase {
       """
       let a = myCollection[index] { $0 < $1 }
       let a = myCollection[label: index] {
-        arg1, arg2 in
+        arg1,
+        arg2 in
         foo()
       }
       let a = myCollection[


### PR DESCRIPTION
The default is currently `true`, which is a reversal of the current implementation. We can change this in the future if desired.