### PR TITLE
Rework OrderedImports rule.

### DIFF
--- a/Tests/SwiftFormatRulesTests/DiagnosingTestCase.swift
+++ b/Tests/SwiftFormatRulesTests/DiagnosingTestCase.swift
@@ -84,14 +84,18 @@ public class DiagnosingTestCase: XCTestCase {
   ///   - expected: The expected result of formatting the input code.
   ///   - file: The file the test resides in (defaults to the current caller's file)
   ///   - line:  The line the test resides in (defaults to the current caller's line)
+  ///   - checkForUnassertedDiagnostics: Fail the test if there are any unasserted linter
+  ///     diagnostics.
   func XCTAssertFormatting(
     _ formatType: SyntaxFormatRule.Type,
     input: String,
     expected: String,
     file: StaticString = #file,
-    line: UInt = #line
+    line: UInt = #line,
+    checkForUnassertedDiagnostics: Bool = false
   ) {
     do {
+      shouldCheckForUnassertedDiagnostics = checkForUnassertedDiagnostics
       let syntax = try SyntaxTreeParser.parse(input)
       let formatter = formatType.init(context: context!)
       let result = formatter.visit(syntax)

--- a/Tests/SwiftFormatRulesTests/OrderedImportsTests.swift
+++ b/Tests/SwiftFormatRulesTests/OrderedImportsTests.swift
@@ -5,126 +5,248 @@ import XCTest
 
 public class OrderedImportsTests: DiagnosingTestCase {
   public func testInvalidImportsOrder() {
+    let input =
+      """
+      import Foundation
+      // Starts Imports
+      import Core
+
+
+      // Comment with new lines
+      import UIKit
+
+      @testable import SwiftFormatRules
+      import enum Darwin.D.isatty
+      // Starts Test
+      @testable import MyModuleUnderTest
+      // Starts Ind
+      import func Darwin.C.isatty
+
+      let a = 3
+      import SwiftSyntax
+      """
+
+    let expected =
+      """
+      // Starts Imports
+      import Core
+      import Foundation
+      import SwiftSyntax
+      // Comment with new lines
+      import UIKit
+
+      // Starts Ind
+      import func Darwin.C.isatty
+      import enum Darwin.D.isatty
+
+      // Starts Test
+      @testable import MyModuleUnderTest
+      @testable import SwiftFormatRules
+
+      let a = 3
+      """
+
     XCTAssertFormatting(
-      OrderedImports.self,
-      input: """
-             import Foundation
-             // Starts Imports
-             import Core
+      OrderedImports.self, input: input, expected: expected, checkForUnassertedDiagnostics: true
+    )
 
+    XCTAssertDiagnosed(.sortImports)  // import Core
+    XCTAssertDiagnosed(.sortImports)  // import func Darwin.C.isatty
+    XCTAssertDiagnosed(.sortImports)  // @testable import MyModuleUnderTest
 
-             // Comment with new lines
-             import UIKit
+    // import SwiftSyntax
+    XCTAssertDiagnosed(.placeAtTopOfFile)
+    XCTAssertDiagnosed(.groupImports(before: .regularImport, after: .declImport))
+    XCTAssertDiagnosed(.groupImports(before: .regularImport, after: .testableImport))
 
-             @testable import SwiftFormatRules
-             import enum Darwin.D.isatty
-             // Starts Test
-             @testable import MyModuleUnderTest
-             // Starts Ind
-             import func Darwin.C.isatty
+    // import func Darwin.C.isatty
+    XCTAssertDiagnosed(.groupImports(before: .declImport, after: .testableImport))
 
-             let a = 3
-             import SwiftSyntax
-             """,
-      expected: """
-                // Starts Imports
-                import Core
-                import Foundation
-                import SwiftSyntax
-                // Comment with new lines
-                import UIKit
-                
-                // Starts Ind
-                import func Darwin.C.isatty
-                import enum Darwin.D.isatty
-
-                // Starts Test
-                @testable import MyModuleUnderTest
-                @testable import SwiftFormatRules
-
-                let a = 3
-                """)
+    // import enum Darwin.D.isatty
+    XCTAssertDiagnosed(.groupImports(before: .declImport, after: .testableImport))
   }
   
   public func testImportsOrderWithoutModuleType() {
+    let input =
+      """
+      @testable import SwiftFormatRules
+      import func Darwin.D.isatty
+      @testable import MyModuleUnderTest
+      import func Darwin.C.isatty
+
+      let a = 3
+      """
+
+    let expected =
+      """
+      import func Darwin.C.isatty
+      import func Darwin.D.isatty
+
+      @testable import MyModuleUnderTest
+      @testable import SwiftFormatRules
+
+      let a = 3
+      """
+
     XCTAssertFormatting(
-      OrderedImports.self,
-      input: """
-             @testable import SwiftFormatRules
-             import func Darwin.D.isatty
-             @testable import MyModuleUnderTest
-             import func Darwin.C.isatty
+      OrderedImports.self, input: input, expected: expected, checkForUnassertedDiagnostics: true
+    )
 
-             let a = 3
-             """,
-      expected: """
-                import func Darwin.C.isatty
-                import func Darwin.D.isatty
+    // import func Darwin.D.isatty
+    XCTAssertDiagnosed(.groupImports(before: .declImport, after: .testableImport))
 
-                @testable import MyModuleUnderTest
-                @testable import SwiftFormatRules
+    // import func Darwin.C.isatty
+    XCTAssertDiagnosed(.groupImports(before: .declImport, after: .testableImport))
+    XCTAssertDiagnosed(.sortImports)
 
-                let a = 3
-                """)
+    // @testable import MyModuleUnderTest
+    XCTAssertDiagnosed(.sortImports)
   }
   
   public func testImportsOrderWithDocComment() {
+    let input =
+      """
+      /// Test imports with comments.
+      ///
+      /// Comments at the top of the file
+      /// should be preserved.
+
+      // Line comment for import
+      // Foundation.
+      import Foundation
+      // Line comment for Core
+      import Core
+      import UIKit
+
+      let a = 3
+      """
+
+    let expected =
+      """
+      /// Test imports with comments.
+      ///
+      /// Comments at the top of the file
+      /// should be preserved.
+
+      // Line comment for Core
+      import Core
+      // Line comment for import
+      // Foundation.
+      import Foundation
+      import UIKit
+
+      let a = 3
+      """
+
     XCTAssertFormatting(
-      OrderedImports.self,
-      input: """
-             /// Test imports with comments.
-             ///
-             /// Comments at the top of the file
-             /// should be preserved.
+      OrderedImports.self, input: input, expected: expected, checkForUnassertedDiagnostics: true
+    )
 
-             // Line comment for import
-             // Foundation.
-             import Foundation
-             // Line comment for Core
-             import Core
-             import UIKit
-
-             let a = 3
-             """,
-      expected: """
-                /// Test imports with comments.
-                ///
-                /// Comments at the top of the file
-                /// should be preserved.
-
-                // Line comment for Core
-                import Core
-                // Line comment for import
-                // Foundation.
-                import Foundation
-                import UIKit
-
-                let a = 3
-                """)
+    // import Core
+    XCTAssertDiagnosed(.sortImports)
   }
   
   public func testValidOrderedImport() {
+    let input =
+      """
+      import CoreLocation
+      import MyThirdPartyModule
+      import SpriteKit
+      import UIKit
+
+      import func Darwin.C.isatty
+
+      @testable import MyModuleUnderTest
+      """
+
+    let expected =
+      """
+      import CoreLocation
+      import MyThirdPartyModule
+      import SpriteKit
+      import UIKit
+
+      import func Darwin.C.isatty
+
+      @testable import MyModuleUnderTest
+      """
+
     XCTAssertFormatting(
-      OrderedImports.self,
-      input: """
-             import CoreLocation
-             import MyThirdPartyModule
-             import SpriteKit
-             import UIKit
+      OrderedImports.self, input: input, expected: expected, checkForUnassertedDiagnostics: true
+    )
 
-             import func Darwin.C.isatty
+    // Should not raise any linter errors.
+  }
 
-             @testable import MyModuleUnderTest
-             """,
-      expected: """
-                import CoreLocation
-                import MyThirdPartyModule
-                import SpriteKit
-                import UIKit
+  public func testSeparatedFileHeader() {
+    let input =
+      """
+      // This is part of the file header.
 
-                import func Darwin.C.isatty
+      // So is this.
 
-                @testable import MyModuleUnderTest
-                """)
+      // Top comment
+      import Bimport
+      import Aimport
+
+      struct MyStruct {
+        // do stuff
+      }
+
+      import HoistMe
+      """
+
+    let expected =
+      """
+      // This is part of the file header.
+
+      // So is this.
+
+      import Aimport
+      // Top comment
+      import Bimport
+      import HoistMe
+
+      struct MyStruct {
+        // do stuff
+      }
+      """
+
+    XCTAssertFormatting(
+      OrderedImports.self, input: input, expected: expected, checkForUnassertedDiagnostics: true
+    )
+
+    // import Aimport
+    XCTAssertDiagnosed(.sortImports)
+
+    // import HoistMe
+    XCTAssertDiagnosed(.placeAtTopOfFile)
+  }
+
+  public func testNonHeaderComment() {
+    let input =
+      """
+      // Top comment
+      import Bimport
+      import Aimport
+
+      let A = 123
+      """
+
+    let expected =
+      """
+      import Aimport
+      // Top comment
+      import Bimport
+
+      let A = 123
+      """
+
+    XCTAssertFormatting(
+      OrderedImports.self, input: input, expected: expected, checkForUnassertedDiagnostics: true
+    )
+
+    // import Aimport
+    XCTAssertDiagnosed(.sortImports)
   }
 }


### PR DESCRIPTION
This a rework of the OrderedImports rule. The new structure should hopefully be easier to follow and allow for easier configurability in the future.