### PR TITLE
Preserve leading trivia when transforming a class to an enum.

### DIFF
--- a/Tests/SwiftFormatRulesTests/UseEnumForNamespacingTests.swift
+++ b/Tests/SwiftFormatRulesTests/UseEnumForNamespacingTests.swift
@@ -24,6 +24,9 @@ public class UseEnumForNamespacingTests: DiagnosingTestCase {
              public final class D {
                static func bar()
              }
+             final class E {
+               static let a = 123
+             }
              """,
       expected: """
                 enum A {
@@ -39,6 +42,9 @@ public class UseEnumForNamespacingTests: DiagnosingTestCase {
                 }
                 public enum D {
                   static func bar()
+                }
+                enum E {
+                  static let a = 123
                 }
                 """)
   }


### PR DESCRIPTION
This PR fixes a bug where the leading trivia is lost when the first keyword is "final", since we remove it when transforming a class to an enum.