### PR TITLE
Fix a bug where code lines are lost for OrderedImports rule

### DIFF
--- a/Sources/SwiftFormatRules/OrderedImports.swift
+++ b/Sources/SwiftFormatRules/OrderedImports.swift
@@ -230,6 +230,12 @@ func generateLines(codeBlockItemList: CodeBlockItemListSyntax) -> [Line] {
   var afterNewline = false
   var isFirstBlock = true
 
+  func appendNewLine() {
+    lines.append(currentLine)
+    currentLine = Line()
+    afterNewline = true  // Note: trailing line comments always come before any newlines.
+  }
+
   for block in codeBlockItemList {
 
     if let leadingTrivia = block.leadingTrivia {
@@ -240,9 +246,7 @@ func generateLines(codeBlockItemList: CodeBlockItemListSyntax) -> [Line] {
         // Create new Line objects when we encounter newlines.
         case .newlines(let N):
           for _ in 0..<N {
-            lines.append(currentLine)
-            currentLine = Line()
-            afterNewline = true  // Note: trailing line comments always come before any newlines.
+            appendNewLine()
           }
         default:
           if afterNewline || isFirstBlock {
@@ -252,6 +256,8 @@ func generateLines(codeBlockItemList: CodeBlockItemListSyntax) -> [Line] {
           }
         }
       }
+    } else if currentLine.codeBlock != nil {
+        appendNewLine()
     }
     currentLine.codeBlock = block  // This represents actual code: imports and otherwise.
     isFirstBlock = false


### PR DESCRIPTION
Hi,

This fix an issue where code blocks are lost during the processing.
This happens when both `NoAccessLevelOnExtensionDeclaration` and `OrderedImports` are active. It basically happens for every declaration (struct, class etc..) followed by any extension declaration that need an update of the modified.

For example, the following code trigger the issue:
```swift
struct Shadow { }
internal extension ShadowExt {}
```