### PR TITLE
Fix false diagnostics in BlankLinesBetweenMembers.

### DIFF
--- a/Sources/SwiftFormatCore/Trivia+Convenience.swift
+++ b/Sources/SwiftFormatCore/Trivia+Convenience.swift
@@ -13,7 +13,7 @@
 import SwiftSyntax
 
 extension Trivia {
-  /// Returns the number of whitespace characters after this node.
+  /// Returns the number of whitespace characters in this trivia.
   public var numberOfSpaces: Int {
     var count = 0
     for piece in self {
@@ -24,12 +24,26 @@ extension Trivia {
     return count
   }
 
-  /// Returns the number of newlines after this node.
+  /// Returns the number of newlines in this trivia.
   public var numberOfNewlines: Int {
     var count = 0
     for piece in self {
       if case .newlines(let n) = piece {
         count += n
+      }
+    }
+    return count
+  }
+
+  /// Returns the number of leading newlines in this trivia.
+  public var numberOfLeadingNewlines: Int {
+    var count = 0
+    loop: for piece in self {
+      switch piece {
+      case .newlines(let n): count += n
+      case .carriageReturns(let n): count += n
+      case .carriageReturnLineFeeds(let n): count += n
+      default: break loop
       }
     }
     return count

--- a/Tests/SwiftFormatRulesTests/BlankLineBetweenMembersTests.swift
+++ b/Tests/SwiftFormatRulesTests/BlankLineBetweenMembersTests.swift
@@ -5,14 +5,52 @@ import SwiftSyntax
 @testable import SwiftFormatRules
 
 public class BlankLineBetweenMembersTests: DiagnosingTestCase {
+  public func testBlankLineBeforeFirstChildOrNot() {
+    XCTAssertFormatting(
+      BlankLineBetweenMembers.self,
+      input: """
+        struct Foo {
+          /// Doc comment
+          func foo() {
+            code()
+          }
+        }
+
+        struct Bar {
+
+          /// Doc comment
+          func bar() {
+            code()
+          }
+        }
+        """,
+      expected: """
+        struct Foo {
+          /// Doc comment
+          func foo() {
+            code()
+          }
+        }
+
+        struct Bar {
+
+          /// Doc comment
+          func bar() {
+            code()
+          }
+        }
+        """
+    )
+  }
+
   public func testInvalidBlankLineBetweenMembers() {
     XCTAssertFormatting(
       BlankLineBetweenMembers.self,
       input: """
              struct foo1 {
-             
-             
-             
+
+
+
                var test1 = 13
                // Multiline
                // comment for b
@@ -21,9 +59,9 @@ public class BlankLineBetweenMembersTests: DiagnosingTestCase {
 
 
                var c = 11
-                    
 
-                      
+
+
 
                // Multiline comment
                // for d
@@ -38,14 +76,22 @@ public class BlankLineBetweenMembersTests: DiagnosingTestCase {
              """,
       expected: """
                 struct foo1 {
-                
+
+
+
                   var test1 = 13
+
                   // Multiline
                   // comment for b
                   var b = 12
+
                   /*BlockComment*/
-                
+
+
                   var c = 11
+
+
+
 
                   // Multiline comment
                   // for d
@@ -60,7 +106,7 @@ public class BlankLineBetweenMembersTests: DiagnosingTestCase {
                 }
                 """)
   }
-  
+
   public func testTwoMembers() {
     XCTAssertFormatting(
       BlankLineBetweenMembers.self,
@@ -94,7 +140,7 @@ public class BlankLineBetweenMembersTests: DiagnosingTestCase {
                 }
                 """)
   }
-  
+
   public func testNestedMembers() {
     XCTAssertFormatting(
       BlankLineBetweenMembers.self,
@@ -107,8 +153,6 @@ public class BlankLineBetweenMembersTests: DiagnosingTestCase {
 
                  case jack, queen, king, ace
                }
-
-
 
                struct secondFoo3 {
                  var a = 1
@@ -123,6 +167,7 @@ public class BlankLineBetweenMembersTests: DiagnosingTestCase {
                   // nested Rank enumeration
                   enum Rank: Int {
                     case two = 2, three, four
+
 
                     case jack, queen, king, ace
                   }


### PR DESCRIPTION
Also remove the bits of the rule that check for violations of maximum contiguous
blank lines; the pretty printer does this.